### PR TITLE
Updates to check data changes

### DIFF
--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -20,8 +20,8 @@ read_extracted_df <- function(filename, target_dir = NULL) {
   # Check if CSV file exists
   if (file.exists(csv_path)) {
     tryCatch({
-      df_latin1 <- suppressWarnings(read.csv(csv_path, fileEncoding = "latin1"))
-      df_utf8 <- suppressWarnings(read.csv(csv_path, fileEncoding = "UTF-8"))
+      df_latin1 <- read.csv(csv_path, fileEncoding = "latin1")
+      df_utf8 <- read.csv(csv_path, fileEncoding = "UTF-8")
       
       if (nrow(df_utf8) > nrow(df_latin1)) {
         return(df_utf8)
@@ -53,10 +53,10 @@ compare_dataframes <- function(new_data, comparison_data) {
 
   # Convert character columns to latin1
   for (col in names(new_data)) {
-    if (is.character(new_data[[col]])) new_data[[col]] <- iconv(new_data[[col]], from = "UTF-8", to = "latin1", sub = "")
+    if (is.character(new_data[[col]])) new_data[[col]] <- suppressWarnings(iconv(new_data[[col]], from = "UTF-8", to = "latin1", sub = ""))
   }
   for (col in names(comparison_data)) {
-    if (is.character(comparison_data[[col]])) comparison_data[[col]] <- iconv(comparison_data[[col]], from = "UTF-8", to = "latin1", sub = "")
+    if (is.character(comparison_data[[col]])) comparison_data[[col]] <- suppressWarnings(iconv(comparison_data[[col]], from = "UTF-8", to = "latin1", sub = ""))
   }
   # Remove fully empty columns from both datasets
   new_data_non_empty_cols <- sapply(new_data, function(col) !all(is.na(col)))

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -112,14 +112,17 @@ compare_dataframes <- function(new_data, old_data) {
 
   } else {
     # Find columns that uniquely identify rows in old_data
+    print_it("Finding columns for matching...", "yellow")
     columns_for_matching <- c()
     done <- FALSE
 
     for (column in common_columns) {
       columns_for_matching <- c(columns_for_matching, column)
 
-      if (nrow(unique(old_data[, columns_for_matching, drop = FALSE])) == old_total) {
+      # Use duplicated() instead of unique() for speed
+      if (!any(duplicated(old_data[, columns_for_matching, drop = FALSE]))) {
         done <- TRUE
+        print_it(paste("Using columns:", paste(columns_for_matching, collapse = ", ")), "yellow")
         break
       }
     }
@@ -131,6 +134,7 @@ compare_dataframes <- function(new_data, old_data) {
   }
 
   # Build data for joining
+  print_it("Building matching data...", "yellow")
   old_for_matching <- old_data[, columns_for_matching, drop = FALSE]
   old_for_matching$old_row_index <- seq_len(old_total)
 
@@ -138,17 +142,17 @@ compare_dataframes <- function(new_data, old_data) {
   new_for_matching$new_row_index <- seq_len(new_total)
 
   # Join based on matching columns
+  print_it("Joining data...", "yellow")
   matched_data <- merge(old_for_matching, new_for_matching, by = columns_for_matching)
   
   unmatched_rows <- old_total - length(unique(matched_data$old_row_index))
 
-  print_it(paste("Matched", nrow(matched_data), "rows"), "yellow")
-  
   if (unmatched_rows > 0) {
     any_change <- TRUE
-    print_it(paste("CAUTION - Could not match", unmatched_rows, "rows in previously extracted data to the data being extracted"), "br_violet")
-    return(any_change)
+    print_it(paste("CAUTION - Could not match", unmatched_rows, "rows from previously extracted data"), "br_violet")
   }
+
+  print_it(paste("Matched", nrow(matched_data), "rows"), "yellow")
 
   # Compare columns
   new_data_matched <- new_data[matched_data$new_row_index, ]

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -20,8 +20,8 @@ read_extracted_df <- function(filename, target_dir = NULL) {
   # Check if CSV file exists
   if (file.exists(csv_path)) {
     tryCatch({
-      df_latin1 <- read.csv(csv_path, fileEncoding = "latin1")
-      df_utf8 <- read.csv(csv_path, fileEncoding = "UTF-8")
+      df_latin1 <- suppressWarnings(read.csv(csv_path, fileEncoding = "latin1"))
+      df_utf8 <- suppressWarnings(read.csv(csv_path, fileEncoding = "UTF-8"))
       
       if (nrow(df_utf8) > nrow(df_latin1)) {
         return(df_utf8)
@@ -95,7 +95,7 @@ compare_dataframes <- function(new_data, comparison_data) {
 
   # Ask user how to match rows
   choice <- menu(c("id (use if there is a common id column in the data being extracted and in the previous extraction)",
-                   "auto (use if there is no common id column; may be slow with >100,000 rows)"),
+                   "auto (use if there is no common id column; may be slow with >10,000 rows)"),
                  title = "How to match rows:")
 
   if (choice == 1) {
@@ -129,7 +129,7 @@ compare_dataframes <- function(new_data, comparison_data) {
 
     if (!done) {
       print_it("Could not automatically match rows - rows are not unique", "br_red")
-      print_it("This can be expected with large datasets (>100,000 rows)", indent = 2)
+      print_it("This can be expected with large datasets (>10,000 rows)", indent = 2)
       print_it("If that is not the case, please check if having duplicate rows in the data being extracted is expected", indent = 2)
       print_it("If there is no common id column and automatic matching fails, consistency with previous extraction should be carefully checked manually", indent = 2)
       debug_matching_subset <<- current_subset

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -41,272 +41,177 @@ read_extracted_df <- function(filename, target_dir = NULL) {
 
 #' Function to compare two dataframes for differences
 #'
-#' This function compares the data being extracted and previously extracted data.
-#' It compares row counts, column names, matches rows, and performs detailed value-by-value comparison.
+#' This function compares the data being extracted against previously extracted data.
+#' It:
+#' - compares the number of rows in the two data frames
+#' - compares column names and logs which ones were added/removed
+#' - matches data line-by-line and compares every value.
 #'
 #' @param new_data data frame of the data being extracted
-#' @param comparison_data data frame of previously extracted data
-compare_dataframes <- function(new_data, comparison_data) {
+#' @param old_data data frame of previously extracted data
+compare_dataframes <- function(new_data, old_data) {
 
-  any_change_found <- FALSE
-  matching_options <- list(
-    id = c("id"),
-    `sample weight, age, sex, and height` = c("sex", "age", "psu", "samplewt_anthro", "height", "height1", "height2", "height3")
-  )
+  any_change <- FALSE
 
-  match_rows <- function(new_df, old_df, by_columns, type, new_total, old_total, fail_threshold) {
-
-    merged <- merge(new_df, old_df, by = by_columns)
-
-    if (nrow(merged) == 0) {
-      print_it(paste("No matching possible based on", type), "br_red")
-      return(NULL)
-    }
-
-    new_unmatched <- new_total - length(unique(merged$.new_idx))
-    old_unmatched <- old_total - length(unique(merged$.old_idx))
-
-    if (new_unmatched > 0) {
-      print_it(paste("CAUTION -", new_unmatched, "rows in new extraction data could not be matched in previously extracted data based on", type), "br_violet")
-    }
-    if (old_unmatched > 0) {
-      print_it(paste("CAUTION -", old_unmatched, "rows in previously extracted data could not be matched in new extraction data based on", type), "br_violet")
-    }
-
-    pct_new_lost <- new_unmatched / new_total
-    pct_old_lost <- old_unmatched / old_total
-
-    if (pct_new_lost >= fail_threshold && pct_old_lost >= fail_threshold) {
-      print_it(paste("No matching possible based on", type), "br_red")
-      return(NULL)
-    }
-
-    print_it(paste("Matched", nrow(merged), "rows based on", type), "yellow")
-
-    return(list(
-      new_idx = merged$.new_idx,
-      old_idx = merged$.old_idx,
-      matched_on = type,
-      match_columns = by_columns,
-      any_change_found = new_unmatched > 0 || old_unmatched > 0
-    ))
+  # Convert character columns to latin1
+  for (col in names(new_data)) {
+    if (is.character(new_data[[col]])) new_data[[col]] <- iconv(new_data[[col]], from = "UTF-8", to = "latin1", sub = "")
   }
-
-  # --- Inner function: compare_values ---
-  # Performs value-by-value comparison on matched rows, excluding the columns used for matching.
-  compare_values <- function(new_data_matched, old_data_matched, matched_on, match_columns, numeric_var_list) {
-
-    values_changed <- FALSE
-
-    print_it(paste("Comparing values of columns other than", matched_on, "after matching based on", matched_on), "yellow")
-
-    common_columns <- setdiff(intersect(colnames(new_data_matched), colnames(old_data_matched)), match_columns)
-
-    for (column_name in common_columns) {
-      new_column_data <- new_data_matched[[column_name]]
-      old_column_data <- old_data_matched[[column_name]]
-
-      # Standardize data types for this column based on std_names_list
-      if (column_name %in% numeric_var_list) {
-        new_column_data <- as.numeric(new_column_data)
-        old_column_data <- as.numeric(old_column_data)
-      } else {
-        if (!is.character(new_column_data)) {
-          new_column_data <- as.character(new_column_data)
-        }
-        if (!is.character(old_column_data)) {
-          old_column_data <- as.character(old_column_data)
-        }
-      }
-
-      # Count changes from or to NA
-      na_to_nonNA_indices <- which(!is.na(new_column_data) & is.na(old_column_data))
-      if (length(na_to_nonNA_indices) > 0) {
-        values_changed <- TRUE
-        print_it(paste("CAUTION -", length(na_to_nonNA_indices), "NA values changed to non-NA in column", column_name), "br_violet")
-        new_values_from_na <- new_column_data[na_to_nonNA_indices]
-        unique_new_values <- unique(new_values_from_na)
-        for (value in unique_new_values[1:min(5, length(unique_new_values))]) {
-          value_count <- sum(new_values_from_na == value, na.rm = TRUE)
-          print_it(paste("NA ->", value, paste0("(", value_count), "cases)"), indent = 2)
-        }
-      }
-      nonNA_to_na_indices <- which(is.na(new_column_data) & !is.na(old_column_data))
-      if (length(nonNA_to_na_indices) > 0) {
-        values_changed <- TRUE
-        print_it(paste("CAUTION -", length(nonNA_to_na_indices), "non-NA values changed to NA in column", column_name), "br_violet")
-        old_values_to_na <- old_column_data[nonNA_to_na_indices]
-        unique_old_values <- unique(old_values_to_na)
-        for (value in unique_old_values[1:min(5, length(unique_old_values))]) {
-          value_count <- sum(old_values_to_na == value, na.rm = TRUE)
-          print_it(paste(value, "-> NA", paste0("(", value_count), "cases)"), indent = 2)
-        }
-      }
-
-      both_not_na <- !is.na(new_column_data) & !is.na(old_column_data)
-      if (sum(both_not_na) > 0) {
-
-        # Check type changes
-        new_is_numeric <- is.numeric(new_column_data)
-        old_is_numeric <- is.numeric(old_column_data)
-
-        if (new_is_numeric && !old_is_numeric) {
-          values_changed <- TRUE
-          stop(paste("ERROR - Column", column_name, "has incompatible data types: new extraction data is numeric but previously extracted data is not"))
-        } else if (!new_is_numeric && old_is_numeric) {
-          values_changed <- TRUE
-          stop(paste("ERROR - Column", column_name, "has incompatible data types: new extraction data is not numeric but previously extracted data is numeric"))
-        }
-
-        # Count value differences (excluding changes from or to NA)
-        value_diff_indices <- c()
-
-        if (new_is_numeric && old_is_numeric) {
-          # Both numeric: precision tolerance
-          value_diff_indices <- which(both_not_na & abs(new_column_data - old_column_data) > 1e-6)
-        } else if (!new_is_numeric && !old_is_numeric) {
-          # Both non-numeric: exact comparison
-          value_diff_indices <- which(both_not_na & new_column_data != old_column_data)
-        }
-
-        if (length(value_diff_indices) > 0) {
-          values_changed <- TRUE
-          print_it(paste("CAUTION -", length(value_diff_indices), "values changed in", column_name), "br_violet")
-
-          # Show unique cases and their counts
-          old_values <- old_column_data[value_diff_indices]
-          new_values <- new_column_data[value_diff_indices]
-          unique_changes <- unique(paste(old_values, "->", new_values))
-          for (change in unique_changes[1:min(5, length(unique_changes))]) {
-            change_count <- sum(paste(old_values, "->", new_values) == change)
-            print_it(paste(change, paste0("(", change_count), "cases)"), indent = 2)
-          }
-        }
-      }
-    }
-
-    return(values_changed)
+  for (col in names(old_data)) {
+    if (is.character(old_data[[col]])) old_data[[col]] <- iconv(old_data[[col]], from = "UTF-8", to = "latin1", sub = "")
   }
-
-  # --- Main logic ---
-
-  # Convert character columns to latin1 for consistent comparison
-  convert_to_latin1 <- function(df) {
-    for (col in names(df)) {
-      if (is.character(df[[col]])) {
-        df[[col]] <- iconv(df[[col]], from = "UTF-8", to = "latin1", sub = "")
-      }
-    }
-    return(df)
-  }
-  new_data <- convert_to_latin1(new_data)
-  comparison_data <- convert_to_latin1(comparison_data)
-
-  # Store original comparison_data for debugging
-  fixed_data <<- comparison_data
-
-  # Get numerical variable names
   numeric_var_list <- as.character(std_names_list$Name[which(std_names_list$Type == "numeric")])
 
-  # Remove fully empty columns from both datasets
-  new_data_non_empty_cols <- sapply(new_data, function(col) !all(is.na(col)))
-  comparison_non_empty_cols <- sapply(comparison_data, function(col) !all(is.na(col)))
-
-  new_data <- new_data[, new_data_non_empty_cols, drop = FALSE]
-  comparison_data <- comparison_data[, comparison_non_empty_cols, drop = FALSE]
+  # Remove fully empty columns
+  new_data <- new_data[, sapply(new_data, function(x) !all(is.na(x))), drop = FALSE]
+  old_data <- old_data[, sapply(old_data, function(x) !all(is.na(x))), drop = FALSE]
 
   # Remove user and ncdrisc_version columns from old data
   # These are written when calling save_extraction()
-  comparison_data <- comparison_data[, !colnames(comparison_data) %in% c("user", "ncdrisc_version"), drop = FALSE]
+  old_data <- old_data[, !colnames(old_data) %in% c("user", "ncdrisc_version"), drop = FALSE]
 
-  # Compare row counts
+  # Compare the number of rows
   new_total <- nrow(new_data)
-  old_total <- nrow(comparison_data)
-
+  old_total <- nrow(old_data)
   if (new_total != old_total) {
-    any_change_found <- TRUE
+    any_change <- TRUE
     print_it("CAUTION - inconsistent number of rows:", "br_violet")
-    print_it(paste("New:", new_total, "vs Old:", old_total), indent = 2)
+    print_it(paste("Data being extracted:", new_total, "vs Previously extracted data:", old_total), indent = 2)
   }
 
-  # Identify columns that are new or have been removed
-  new_file_columns <- colnames(new_data)
-  old_file_columns <- colnames(comparison_data)
-
-  new_columns <- setdiff(new_file_columns, old_file_columns)
-  removed_columns <- setdiff(old_file_columns, new_file_columns)
-
-  if (length(new_columns) > 0) {
-    any_change_found <- TRUE
-    print_it("CAUTION - added columns:", "br_violet")
-    print_it(new_columns, indent = 2)
-
-    # Save added columns dataframe to workspace to then run summary(added_columns) from the main script
-    added_columns <<- new_data[, new_columns, drop = FALSE]
+  # Compare column names
+  new_cols <- setdiff(colnames(new_data), colnames(old_data))
+  removed_cols <- setdiff(colnames(old_data), colnames(new_data))
+  if (length(new_cols) > 0) {
+    any_change <- TRUE
+    print_it("CAUTION - Added columns:", "br_violet")
+    print_it(new_cols, indent = 2)
+    added_columns <<- new_data[, new_cols, drop = FALSE]
+  }
+  if (length(removed_cols) > 0) {
+    any_change <- TRUE
+    print_it("CAUTION - Removed columns:", "br_violet")
+    print_it(removed_cols, indent = 2)
   }
 
-  if (length(removed_columns) > 0) {
-    any_change_found <- TRUE
-    print_it("CAUTION - removed columns:", "br_violet")
-    print_it(removed_columns, indent = 2)
-  }
+  # Ask user how to match rows
+  choice <- menu(c("id (use if id column has not changed)",
+                   "auto (use if id column has changed)"),
+                 title = "How to match rows:")
+  
+  common_columns <- intersect(colnames(old_data), colnames(new_data))
 
-  # Match rows: try id first
-  new_id_df <- data.frame(id = new_data[["id"]], .new_idx = seq_len(new_total))
-  old_id_df <- data.frame(id = comparison_data[["id"]], .old_idx = seq_len(old_total))
-
-  match_result <- match_rows(new_id_df, old_id_df, matching_options[["id"]], "id", new_total, old_total, fail_threshold = 0.1)
-
-  # If id matching failed, try matching based on sample weight, age, sex, and height
-  if (is.null(match_result)) {
-    fallback_type <- names(matching_options)[2]
-    print_it(paste("Trying to match based on", fallback_type), "yellow")
-
-    match_columns <- intersect(matching_options[[fallback_type]], intersect(colnames(new_data), colnames(comparison_data)))
-
-    if (length(match_columns) == 0) {
-      print_it(paste("No matching possible based on", fallback_type), "br_red")
-      return(any_change_found)
+  if (choice == 1) {
+    # Match by id
+    if (!"id" %in% common_columns) {
+      print_it("No id column found", "br_red")
+      return(any_change)
     }
+    columns_for_matching <- "id"
+    print_it("Matching by id", "yellow")
 
-    round_column <- function(df, col) {
-      if (is.numeric(df[[col]])) {
-        if (col %in% c("height", "height1", "height2", "height3")) {
-          return(round(df[[col]], 0))
-        } else {
-          return(round(df[[col]]))
-        }
+  } else {
+    # Find columns that uniquely identify rows in old_data
+    columns_for_matching <- c()
+    done <- FALSE
+
+    for (column in common_columns) {
+      columns_for_matching <- c(columns_for_matching, column)
+
+      if (nrow(unique(old_data[, columns_for_matching, drop = FALSE])) == old_total) {
+        done <- TRUE
+        break
       }
-      return(df[[col]])
     }
 
-    new_match_df <- data.frame(lapply(match_columns, function(k) round_column(new_data, k)))
-    old_match_df <- data.frame(lapply(match_columns, function(k) round_column(comparison_data, k)))
-    colnames(new_match_df) <- match_columns
-    colnames(old_match_df) <- match_columns
-    new_match_df$.new_idx <- seq_len(new_total)
-    old_match_df$.old_idx <- seq_len(old_total)
-
-    match_result <- match_rows(new_match_df, old_match_df, match_columns, fallback_type, new_total, old_total, fail_threshold = 0.1)
-
-    if (is.null(match_result)) {
-      return(any_change_found)
+    if (!done) {
+      print_it("Could not automatically match rows", "br_red")
+      return(any_change)
     }
   }
 
-  if (match_result$any_change_found) {
-    any_change_found <- TRUE
+  # Build data for joining
+  old_for_matching <- old_data[, columns_for_matching, drop = FALSE]
+  old_for_matching$old_row_index <- seq_len(old_total)
+
+  new_for_matching <- new_data[, columns_for_matching, drop = FALSE]
+  new_for_matching$new_row_index <- seq_len(new_total)
+
+  # Join based on matching columns
+  matched_data <- merge(old_for_matching, new_for_matching, by = columns_for_matching)
+  
+  unmatched_rows <- old_total - length(unique(matched_data$old_row_index))
+
+  print_it(paste("Matched", nrow(matched_data), "rows"), "yellow")
+  
+  if (unmatched_rows > 0) {
+    any_change <- TRUE
+    print_it(paste("CAUTION - Could not match", unmatched_rows, "rows in previously extracted data to the data being extracted"), "br_violet")
+    return(any_change)
   }
 
-  # Subset to matched rows and compare values
-  new_data_matched <- new_data[match_result$new_idx, ]
-  old_data_matched <- comparison_data[match_result$old_idx, ]
+  # Compare columns
+  new_data_matched <- new_data[matched_data$new_row_index, ]
+  old_data_matched <- old_data[matched_data$old_row_index, ]
+  columns_to_compare <- intersect(colnames(new_data_matched), colnames(old_data_matched))
 
-  if (compare_values(new_data_matched, old_data_matched, match_result$matched_on, match_result$match_columns, numeric_var_list)) {
-    any_change_found <- TRUE
+  print_it(paste("Comparing", length(columns_to_compare), "columns"), "yellow")
+
+  for (column in columns_to_compare) {
+    new_values <- new_data_matched[[column]]
+    old_values <- old_data_matched[[column]]
+
+    if (column %in% numeric_var_list) {
+      new_values <- as.numeric(new_values)
+      old_values <- as.numeric(old_values)
+    } else {
+      if (!is.character(new_values)) new_values <- as.character(new_values)
+      if (!is.character(old_values)) old_values <- as.character(old_values)
+    }
+
+    # NA to value
+    changed_indices <- which(!is.na(new_values) & is.na(old_values))
+    if (length(changed_indices) > 0) {
+      any_change <- TRUE
+      print_it(paste("CAUTION -", length(changed_indices), "NA changed to value in", column), "br_violet")
+      values <- new_values[changed_indices]
+      for (v in unique(values)[1:min(5, length(unique(values)))]) {
+        print_it(paste("NA ->", v, paste0("(", sum(values == v, na.rm = TRUE), ")")), indent = 2)
+      }
+    }
+
+    # Value to NA
+    changed_indices <- which(is.na(new_values) & !is.na(old_values))
+    if (length(changed_indices) > 0) {
+      any_change <- TRUE
+      print_it(paste("CAUTION -", length(changed_indices), "values changed to NA in", column), "br_violet")
+      values <- old_values[changed_indices]
+      for (v in unique(values)[1:min(5, length(unique(values)))]) {
+        print_it(paste(v, "-> NA", paste0("(", sum(values == v, na.rm = TRUE), ")")), indent = 2)
+      }
+    }
+
+    # Value changes
+    both_have_values <- !is.na(new_values) & !is.na(old_values)
+    if (sum(both_have_values) == 0) next
+
+    if (is.numeric(new_values)) {
+      changed_indices <- which(both_have_values & abs(new_values - old_values) > 1e-6)
+    } else {
+      changed_indices <- which(both_have_values & new_values != old_values)
+    }
+
+    if (length(changed_indices) > 0) {
+      any_change <- TRUE
+      print_it(paste("CAUTION -", length(changed_indices), "values changed in", column), "br_violet")
+      changes <- paste(old_values[changed_indices], "->", new_values[changed_indices])
+      for (change in unique(changes)[1:min(5, length(unique(changes)))]) {
+        print_it(paste(change, paste0("(", sum(changes == change), ")")), indent = 2)
+      }
+    }
   }
 
-  return(any_change_found)
+  return(any_change)
 }
 
 
@@ -329,16 +234,16 @@ check_data_changes <- function(data, filename, study_dir = NULL, extracted_data_
     print_it("Checking changes in data in comparison with the following file...", "yellow")
     print_it(paste0(curr_dir, filename, ".csv"), indent = 2)
 
-    # Load comparison data using read_extracted_df
-    comparison_data <- read_extracted_df(filename, curr_dir)
+    # Load old data using read_extracted_df
+    old_data <- read_extracted_df(filename, curr_dir)
 
-    if (is.null(comparison_data)) {
+    if (is.null(old_data)) {
       print_it(paste("ERROR - file does not exist"), "br_red")
       return(invisible())
     }
 
     # Call compare_dataframes to do the actual comparison
-    found_any <- compare_dataframes(data, comparison_data)
+    found_any <- compare_dataframes(data, old_data)
 
     if (!found_any) print_it("No changes found", "yellow")
 

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -20,7 +20,16 @@ read_extracted_df <- function(filename, target_dir = NULL) {
   # Check if CSV file exists
   if (file.exists(csv_path)) {
     tryCatch({
-      return(read.csv(csv_path))
+      df_latin1 <- read.csv(csv_path, fileEncoding = "latin1")
+      df_utf8 <- read.csv(csv_path)
+
+      if (nrow(df_latin1) != nrow(df_utf8)) {
+        print_it("(read as UTF-8)", "yellow")
+        return(df_utf8)
+      } else {
+        print_it("(read as latin1)", "yellow")
+        return(df_latin1)
+      }
     }, error = function(e) {
       return(NULL)
     })

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -58,8 +58,6 @@ compare_dataframes <- function(new_data, old_data) {
   for (col in names(old_data)) {
     if (is.character(old_data[[col]])) old_data[[col]] <- iconv(old_data[[col]], from = "UTF-8", to = "latin1", sub = "")
   }
-  numeric_var_list <- as.character(std_names_list$Name[which(std_names_list$Type == "numeric")])
-
   # Remove fully empty columns
   new_data <- new_data[, sapply(new_data, function(x) !all(is.na(x))), drop = FALSE]
   old_data <- old_data[, sapply(old_data, function(x) !all(is.na(x))), drop = FALSE]
@@ -67,7 +65,11 @@ compare_dataframes <- function(new_data, old_data) {
   # Remove user and ncdrisc_version columns from old data
   # These are written when calling save_extraction()
   old_data <- old_data[, !colnames(old_data) %in% c("user", "ncdrisc_version"), drop = FALSE]
-  
+
+  std_names_list <- ncdrisc::std_names_list
+  common_columns <- intersect(colnames(new_data), colnames(old_data))
+  numeric_columns <- as.character(std_names_list$Name[which(std_names_list$Type == "numeric")])
+
   # Compare column names
   new_cols <- setdiff(colnames(new_data), colnames(old_data))
   removed_cols <- setdiff(colnames(old_data), colnames(new_data))
@@ -87,8 +89,6 @@ compare_dataframes <- function(new_data, old_data) {
   choice <- menu(c("id (use if there is a common id column in the data being extracted and in the previous extraction)",
                    "auto (use if there is no common id column; may be slow with >100,000 rows)"),
                  title = "How to match rows:")
-  
-  common_columns <- intersect(colnames(old_data), colnames(new_data))
 
   if (choice == 1) {
     # Match by id
@@ -105,7 +105,7 @@ compare_dataframes <- function(new_data, old_data) {
 
     available_columns <- common_columns[common_columns != "id"]
     available_columns <- available_columns[!grepl("^age_min_|^age_max_|^is_|_year$", available_columns)]
-    available_columns <- available_columns[available_columns %in% numeric_var_list]
+    available_columns <- available_columns[available_columns %in% numeric_columns]
     print_it(paste("Numeric columns available:", paste(available_columns, collapse = ", ")), "yellow")
 
     columns_for_matching <- c()
@@ -151,18 +151,17 @@ compare_dataframes <- function(new_data, old_data) {
   }
 
   matched_data <- matched_data[!is.na(matched_data$old_row_index), ]
-  columns_to_compare <- intersect(colnames(new_data), colnames(old_data))
 
-  print_it(paste("Comparing", nrow(matched_data), "rows across", length(columns_to_compare), "columns"), "yellow")
+  print_it(paste("Comparing", nrow(matched_data), "rows across", length(common_columns), "columns"), "yellow")
 
   new_data_matched <- new_data[matched_data$new_row_index, ]
   old_data_matched <- old_data[matched_data$old_row_index, ]
 
-  for (column in columns_to_compare) {
+  for (column in common_columns) {
     new_values <- new_data_matched[[column]]
     old_values <- old_data_matched[[column]]
 
-    if (column %in% numeric_var_list) {
+    if (column %in% numeric_columns) {
       new_values <- as.numeric(new_values)
       old_values <- as.numeric(old_values)
     } else {

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -172,44 +172,51 @@ compare_dataframes <- function(new_data, old_data) {
       if (!is.character(old_values)) old_values <- as.character(old_values)
     }
 
-    # NA to value
-    changed_indices <- which(!is.na(new_values) & is.na(old_values))
-    if (length(changed_indices) > 0) {
+    # Count changes from or to NA
+    na_to_nonNA_indices <- which(!is.na(new_values) & is.na(old_values))
+    if (length(na_to_nonNA_indices) > 0) {
       any_change <- TRUE
-      print_it(paste("CAUTION -", length(changed_indices), "NA changed to value in", column), "br_violet")
-      values <- new_values[changed_indices]
-      for (v in unique(values)[1:min(5, length(unique(values)))]) {
-        print_it(paste("NA ->", v, paste0("(", sum(values == v, na.rm = TRUE), ")")), indent = 2)
+      print_it(paste("CAUTION -", length(na_to_nonNA_indices), "NA values changed to non-NA in column", column), "br_violet")
+      new_values_from_na <- new_values[na_to_nonNA_indices]
+      unique_new_values <- unique(new_values_from_na)
+      for (value in unique_new_values[1:min(5, length(unique_new_values))]) {
+        value_count <- sum(new_values_from_na == value, na.rm = TRUE)
+        print_it(paste("NA ->", value, paste0("(", value_count), "cases)"), indent = 2)
+      }
+    }
+    nonNA_to_na_indices <- which(is.na(new_values) & !is.na(old_values))
+    if (length(nonNA_to_na_indices) > 0) {
+      any_change <- TRUE
+      print_it(paste("CAUTION -", length(nonNA_to_na_indices), "non-NA values changed to NA in column", column), "br_violet")
+      old_values_to_na <- old_values[nonNA_to_na_indices]
+      unique_old_values <- unique(old_values_to_na)
+      for (value in unique_old_values[1:min(5, length(unique_old_values))]) {
+        value_count <- sum(old_values_to_na == value, na.rm = TRUE)
+        print_it(paste(value, "-> NA", paste0("(", value_count), "cases)"), indent = 2)
       }
     }
 
-    # Value to NA
-    changed_indices <- which(is.na(new_values) & !is.na(old_values))
-    if (length(changed_indices) > 0) {
-      any_change <- TRUE
-      print_it(paste("CAUTION -", length(changed_indices), "values changed to NA in", column), "br_violet")
-      values <- old_values[changed_indices]
-      for (v in unique(values)[1:min(5, length(unique(values)))]) {
-        print_it(paste(v, "-> NA", paste0("(", sum(values == v, na.rm = TRUE), ")")), indent = 2)
-      }
-    }
+    both_not_na <- !is.na(new_values) & !is.na(old_values)
+    if (sum(both_not_na) == 0) next
 
-    # Value changes
-    both_have_values <- !is.na(new_values) & !is.na(old_values)
-    if (sum(both_have_values) == 0) next
-
+    value_diff_indices <- c()
     if (is.numeric(new_values)) {
-      changed_indices <- which(both_have_values & abs(new_values - old_values) > 1e-6)
+      value_diff_indices <- which(both_not_na & abs(new_values - old_values) > 1e-6)
     } else {
-      changed_indices <- which(both_have_values & new_values != old_values)
+      for (i in which(both_not_na)) {
+        if (new_values[i] != old_values[i]) {
+          value_diff_indices <- c(value_diff_indices, i)
+        }
+      }
     }
 
-    if (length(changed_indices) > 0) {
+    if (length(value_diff_indices) > 0) {
       any_change <- TRUE
-      print_it(paste("CAUTION -", length(changed_indices), "values changed in", column), "br_violet")
-      changes <- paste(old_values[changed_indices], "->", new_values[changed_indices])
-      for (change in unique(changes)[1:min(5, length(unique(changes)))]) {
-        print_it(paste(change, paste0("(", sum(changes == change), ")")), indent = 2)
+      print_it(paste("CAUTION -", length(value_diff_indices), "values changed in", column), "br_violet")
+      unique_changes <- unique(paste(old_values[value_diff_indices], "->", new_values[value_diff_indices]))
+      for (change in unique_changes[1:min(5, length(unique_changes))]) {
+        change_count <- sum(paste(old_values[value_diff_indices], "->", new_values[value_diff_indices]) == change)
+        print_it(paste(change, paste0("(", change_count), "cases)"), indent = 2)
       }
     }
   }

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -69,16 +69,7 @@ compare_dataframes <- function(new_data, old_data) {
   # Remove user and ncdrisc_version columns from old data
   # These are written when calling save_extraction()
   old_data <- old_data[, !colnames(old_data) %in% c("user", "ncdrisc_version"), drop = FALSE]
-
-  # Compare the number of rows
-  new_total <- nrow(new_data)
-  old_total <- nrow(old_data)
-  if (new_total != old_total) {
-    any_change <- TRUE
-    print_it("CAUTION - inconsistent number of rows:", "br_violet")
-    print_it(paste("Data being extracted:", new_total, "vs Previously extracted data:", old_total), indent = 2)
-  }
-
+  
   # Compare column names
   new_cols <- setdiff(colnames(new_data), colnames(old_data))
   removed_cols <- setdiff(colnames(old_data), colnames(new_data))
@@ -140,33 +131,24 @@ compare_dataframes <- function(new_data, old_data) {
     }
   }
 
-  # Build data for joining
-  print_it("Building matching data...", "yellow")
-  old_for_matching <- old_data[, columns_for_matching, drop = FALSE]
-  old_for_matching$old_row_index <- seq_len(old_total)
-
   new_for_matching <- new_data[, columns_for_matching, drop = FALSE]
   new_for_matching$new_row_index <- seq_len(new_total)
 
-  # Join based on matching columns
-  print_it("Joining data...", "yellow")
-  matched_data <- merge(old_for_matching, new_for_matching, by = columns_for_matching)
-  
-  unmatched_rows <- old_total - length(unique(matched_data$old_row_index))
+  old_for_matching <- old_data[, columns_for_matching, drop = FALSE]
+  old_for_matching$old_row_index <- seq_len(old_total)
 
-  if (unmatched_rows > 0) {
-    any_change <- TRUE
-    print_it(paste("CAUTION - Could not match", unmatched_rows, "rows from previously extracted data"), "br_violet")
-  }
+  matched_data <- merge(new_for_matching, old_for_matching, by = columns_for_matching, all.x = TRUE)
 
-  print_it(paste("Matched", nrow(matched_data), "rows"), "yellow")
+  new_rows <- sum(is.na(matched_data$old_row_index))
+  if (new_rows > 0) print_it(paste(new_rows, "new rows"), "yellow")
 
-  # Compare columns
+  matched_data <- matched_data[!is.na(matched_data$old_row_index), ]
+  columns_to_compare <- intersect(colnames(new_data), colnames(old_data))
+
+  print_it(paste("Comparing", nrow(matched_data), "rows across", length(columns_to_compare), "columns"), "yellow")
+
   new_data_matched <- new_data[matched_data$new_row_index, ]
   old_data_matched <- old_data[matched_data$old_row_index, ]
-  columns_to_compare <- intersect(colnames(new_data_matched), colnames(old_data_matched))
-
-  print_it(paste("Comparing", length(columns_to_compare), "columns"), "yellow")
 
   for (column in columns_to_compare) {
     new_values <- new_data_matched[[column]]

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -102,9 +102,8 @@ compare_dataframes <- function(new_data, old_data) {
     print_it("Matching by id", "yellow")
 
   } else {
-    # Find columns that uniquely identify rows in old_data
+    # Find columns that uniquely identify rows
     # Exclude "id" and metadata columns
-    print_it("Finding columns for matching...", "yellow")
 
     available_columns <- common_columns[common_columns != "id"]
     available_columns <- available_columns[!grepl("^age_min_|^age_max_|^is_|_year$", available_columns)]

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -22,14 +22,10 @@ read_extracted_df <- function(filename, target_dir = NULL) {
     tryCatch({
       df_latin1 <- read.csv(csv_path, fileEncoding = "latin1")
       df_utf8 <- read.csv(csv_path, fileEncoding = "UTF-8")
-
-      print_it(paste("latin1:", nrow(df_latin1), "rows", ncol(df_latin1), "cols | UTF-8:", nrow(df_utf8), "rows", ncol(df_utf8), "cols"), "yellow")
-
-      if (nrow(df_latin1) != nrow(df_utf8)) {
-        print_it("(read as UTF-8)", "yellow")
+      
+      if (nrow(df_utf8) > nrow(df_latin1)) {
         return(df_utf8)
       } else {
-        print_it("(read as latin1)", "yellow")
         return(df_latin1)
       }
     }, error = function(e) {

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -105,9 +105,6 @@ compare_dataframes <- function(new_data, comparison_data) {
       return(any_change_found)
     }
     columns_for_matching <- "id"
-    print_it(paste("Matching by id | new id class:", class(new_data$id), "| old id class:", class(comparison_data$id)), "yellow")
-    print_it(paste("new ids sample:", paste(head(new_data$id, 3), collapse=", ")), "yellow")
-    print_it(paste("old ids sample:", paste(head(comparison_data$id, 3), collapse=", ")), "yellow")
 
   } else {
     # Find columns that uniquely identify rows
@@ -116,7 +113,6 @@ compare_dataframes <- function(new_data, comparison_data) {
     available_columns <- common_columns[common_columns != "id"]
     available_columns <- available_columns[!grepl("^age_min_|^age_max_|^is_|_year$", available_columns)]
     available_columns <- available_columns[available_columns %in% numeric_var_list]
-    print_it(paste("Numeric columns available:", paste(available_columns, collapse = ", ")), "yellow")
 
     columns_for_matching <- c()
     done <- FALSE

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -97,7 +97,9 @@ compare_dataframes <- function(new_data, old_data) {
       return(any_change)
     }
     columns_for_matching <- "id"
-    print_it("Matching by id", "yellow")
+    print_it(paste("Matching by id | new id class:", class(new_data$id), "| old id class:", class(old_data$id)), "yellow")
+    print_it(paste("new ids sample:", paste(head(new_data$id, 3), collapse=", ")), "yellow")
+    print_it(paste("old ids sample:", paste(head(old_data$id, 3), collapse=", ")), "yellow")
 
   } else {
     # Find columns that uniquely identify rows
@@ -138,6 +140,7 @@ compare_dataframes <- function(new_data, old_data) {
   old_for_matching$old_row_index <- seq_len(nrow(old_data))
 
   matched_data <- merge(new_for_matching, old_for_matching, by = columns_for_matching, all.x = TRUE)
+  print_it(paste("Merge result:", nrow(matched_data), "rows |", sum(!is.na(matched_data$old_row_index)), "matched |", sum(is.na(matched_data$old_row_index)), "unmatched"), "yellow")
 
   new_rows <- sum(is.na(matched_data$old_row_index))
   removed_rows <- nrow(old_data) - length(unique(na.omit(matched_data$old_row_index)))

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -227,11 +227,7 @@ compare_dataframes <- function(new_data, old_data) {
         value_diff_indices <- which(both_not_na & abs(new_column_data - old_column_data) > 1e-6)
       } else if (!new_is_numeric && !old_is_numeric) {
         # Both non-numeric: exact comparison
-        for (i in which(both_not_na)) {
-          if (new_column_data[i] != old_column_data[i]) {
-            value_diff_indices <- c(value_diff_indices, i)
-          }
-        }
+        value_diff_indices <- which(both_not_na & new_column_data != old_column_data)
       }
 
       if (length(value_diff_indices) > 0) {

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -42,6 +42,16 @@ compare_dataframes <- function(new_data, comparison_data) {
   # flag for if any change was found
   any_change_found <- FALSE
 
+  # Convert both datasets to latin1
+  new_data[] <- lapply(new_data, function(x) {
+    if (is.character(x)) iconv(x, from = "latin1", to = "UTF-8", sub = "")
+    else x
+  })
+  comparison_data[] <- lapply(comparison_data, function(x) {
+    if (is.character(x)) iconv(x, from = "latin1", to = "UTF-8", sub = "")
+    else x
+  })
+
   # Store original comparison_data for debugging
   fixed_data <<- comparison_data
 

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -116,7 +116,7 @@ compare_dataframes <- function(new_data, old_data) {
     print_it("Finding columns for matching...", "yellow")
 
     available_columns <- common_columns[common_columns %in% numeric_var_list & common_columns != "id"]
-    print_it(paste("Numeric columns available:", length(numeric_columns)), "yellow")
+    print_it(paste("Numeric columns available:", length(available_columns)), "yellow")
 
     columns_for_matching <- c()
     done <- FALSE

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -127,6 +127,23 @@ compare_dataframes <- function(new_data, comparison_data) {
       comparison_data_ordered <- comparison_data[order(comparison_data[[id_column]]), ]
 
     } else {
+      # IDs do not match
+      if (new_row_count != old_row_count) {
+        print_it("CAUTION - IDs do not fully match (the number of rows is different)", "br_violet")
+      } else {
+        print_it("CAUTION - IDs do not match", "br_violet")
+      }
+
+      # Check if value matching should proceed
+      if (max(new_row_count, old_row_count) > 10000) {
+        user_input <- readline(prompt = "Do you want to match on values? It could take a long time (y/n): ")
+        if (tolower(user_input) != "y") {
+          return(any_change_found)
+        }
+      }
+
+      print_it("Trying to match on values...", "yellow")
+
       # STRATEGY B: Fall back to sorting by columns with matching means
       common_columns <- intersect(colnames(new_data), colnames(comparison_data))
       matching_mean_columns <- c()
@@ -222,11 +239,7 @@ compare_dataframes <- function(new_data, comparison_data) {
             value_diff_indices <- which(both_not_na & abs(new_column_data - old_column_data) > 1e-6)
           } else if (!new_is_numeric && !old_is_numeric) {
             # Both non-numeric: exact comparison
-            for (i in which(both_not_na)) {
-              if (new_column_data[i] != old_column_data[i]) {
-                value_diff_indices <- c(value_diff_indices, i)
-              }
-            }
+            value_diff_indices <- which(both_not_na & new_column_data != old_column_data)
           }
 
           if (length(value_diff_indices) > 0) {

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -119,8 +119,7 @@ compare_dataframes <- function(new_data, old_data) {
     for (column in common_columns) {
       columns_for_matching <- c(columns_for_matching, column)
 
-      # Use duplicated() instead of unique() for speed
-      if (!any(duplicated(old_data[, columns_for_matching, drop = FALSE]))) {
+      if (anyDuplicated(old_data[, columns_for_matching, drop = FALSE]) == 0) {
         done <- TRUE
         print_it(paste("Using columns:", paste(columns_for_matching, collapse = ", ")), "yellow")
         break

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -41,16 +41,155 @@ read_extracted_df <- function(filename, target_dir = NULL) {
 
 #' Function to compare two dataframes for differences
 #'
-#' This function performs comprehensive comparison between new and existing extraction data.
-#' It compares row counts, column names, and performs detailed value-by-value comparison.
+#' This function compares the data being extracted and previously extracted data.
+#' It compares row counts, column names, matches rows, and performs detailed value-by-value comparison.
 #'
-#' @param new_data data frame of new extraction data
+#' @param new_data data frame of the data being extracted
 #' @param comparison_data data frame of previously extracted data
 compare_dataframes <- function(new_data, comparison_data) {
 
-  # flag for if any change was found
   any_change_found <- FALSE
-  
+  matching_options <- list(
+    id = c("id"),
+    `sample weight, age, sex, and height` = c("sex", "age", "psu", "samplewt_anthro", "height", "height1", "height2", "height3")
+  )
+
+  match_rows <- function(new_df, old_df, by_columns, type, new_total, old_total, fail_threshold) {
+
+    merged <- merge(new_df, old_df, by = by_columns)
+
+    if (nrow(merged) == 0) {
+      print_it(paste("No matching possible based on", type), "br_red")
+      return(NULL)
+    }
+
+    new_unmatched <- new_total - length(unique(merged$.new_idx))
+    old_unmatched <- old_total - length(unique(merged$.old_idx))
+
+    if (new_unmatched > 0) {
+      print_it(paste("CAUTION -", new_unmatched, "rows in new extraction data could not be matched in previously extracted data based on", type), "br_violet")
+    }
+    if (old_unmatched > 0) {
+      print_it(paste("CAUTION -", old_unmatched, "rows in previously extracted data could not be matched in new extraction data based on", type), "br_violet")
+    }
+
+    pct_new_lost <- new_unmatched / new_total
+    pct_old_lost <- old_unmatched / old_total
+
+    if (pct_new_lost >= fail_threshold && pct_old_lost >= fail_threshold) {
+      print_it(paste("No matching possible based on", type), "br_red")
+      return(NULL)
+    }
+
+    print_it(paste("Matched", nrow(merged), "rows based on", type), "yellow")
+
+    return(list(
+      new_idx = merged$.new_idx,
+      old_idx = merged$.old_idx,
+      matched_on = type,
+      match_columns = by_columns,
+      any_change_found = new_unmatched > 0 || old_unmatched > 0
+    ))
+  }
+
+  # --- Inner function: compare_values ---
+  # Performs value-by-value comparison on matched rows, excluding the columns used for matching.
+  compare_values <- function(new_data_matched, old_data_matched, matched_on, match_columns, numeric_var_list) {
+
+    values_changed <- FALSE
+
+    print_it(paste("Comparing values of columns other than", matched_on, "after matching based on", matched_on), "yellow")
+
+    common_columns <- setdiff(intersect(colnames(new_data_matched), colnames(old_data_matched)), match_columns)
+
+    for (column_name in common_columns) {
+      new_column_data <- new_data_matched[[column_name]]
+      old_column_data <- old_data_matched[[column_name]]
+
+      # Standardize data types for this column based on std_names_list
+      if (column_name %in% numeric_var_list) {
+        new_column_data <- as.numeric(new_column_data)
+        old_column_data <- as.numeric(old_column_data)
+      } else {
+        if (!is.character(new_column_data)) {
+          new_column_data <- as.character(new_column_data)
+        }
+        if (!is.character(old_column_data)) {
+          old_column_data <- as.character(old_column_data)
+        }
+      }
+
+      # Count changes from or to NA
+      na_to_nonNA_indices <- which(!is.na(new_column_data) & is.na(old_column_data))
+      if (length(na_to_nonNA_indices) > 0) {
+        values_changed <- TRUE
+        print_it(paste("CAUTION -", length(na_to_nonNA_indices), "NA values changed to non-NA in column", column_name), "br_violet")
+        new_values_from_na <- new_column_data[na_to_nonNA_indices]
+        unique_new_values <- unique(new_values_from_na)
+        for (value in unique_new_values[1:min(5, length(unique_new_values))]) {
+          value_count <- sum(new_values_from_na == value, na.rm = TRUE)
+          print_it(paste("NA ->", value, paste0("(", value_count), "cases)"), indent = 2)
+        }
+      }
+      nonNA_to_na_indices <- which(is.na(new_column_data) & !is.na(old_column_data))
+      if (length(nonNA_to_na_indices) > 0) {
+        values_changed <- TRUE
+        print_it(paste("CAUTION -", length(nonNA_to_na_indices), "non-NA values changed to NA in column", column_name), "br_violet")
+        old_values_to_na <- old_column_data[nonNA_to_na_indices]
+        unique_old_values <- unique(old_values_to_na)
+        for (value in unique_old_values[1:min(5, length(unique_old_values))]) {
+          value_count <- sum(old_values_to_na == value, na.rm = TRUE)
+          print_it(paste(value, "-> NA", paste0("(", value_count), "cases)"), indent = 2)
+        }
+      }
+
+      both_not_na <- !is.na(new_column_data) & !is.na(old_column_data)
+      if (sum(both_not_na) > 0) {
+
+        # Check type changes
+        new_is_numeric <- is.numeric(new_column_data)
+        old_is_numeric <- is.numeric(old_column_data)
+
+        if (new_is_numeric && !old_is_numeric) {
+          values_changed <- TRUE
+          stop(paste("ERROR - Column", column_name, "has incompatible data types: new extraction data is numeric but previously extracted data is not"))
+        } else if (!new_is_numeric && old_is_numeric) {
+          values_changed <- TRUE
+          stop(paste("ERROR - Column", column_name, "has incompatible data types: new extraction data is not numeric but previously extracted data is numeric"))
+        }
+
+        # Count value differences (excluding changes from or to NA)
+        value_diff_indices <- c()
+
+        if (new_is_numeric && old_is_numeric) {
+          # Both numeric: precision tolerance
+          value_diff_indices <- which(both_not_na & abs(new_column_data - old_column_data) > 1e-6)
+        } else if (!new_is_numeric && !old_is_numeric) {
+          # Both non-numeric: exact comparison
+          value_diff_indices <- which(both_not_na & new_column_data != old_column_data)
+        }
+
+        if (length(value_diff_indices) > 0) {
+          values_changed <- TRUE
+          print_it(paste("CAUTION -", length(value_diff_indices), "values changed in", column_name), "br_violet")
+
+          # Show unique cases and their counts
+          old_values <- old_column_data[value_diff_indices]
+          new_values <- new_column_data[value_diff_indices]
+          unique_changes <- unique(paste(old_values, "->", new_values))
+          for (change in unique_changes[1:min(5, length(unique_changes))]) {
+            change_count <- sum(paste(old_values, "->", new_values) == change)
+            print_it(paste(change, paste0("(", change_count), "cases)"), indent = 2)
+          }
+        }
+      }
+    }
+
+    return(values_changed)
+  }
+
+  # --- Main logic ---
+
   # Convert character columns to latin1 for consistent comparison
   convert_to_latin1 <- function(df) {
     for (col in names(df)) {
@@ -62,6 +201,9 @@ compare_dataframes <- function(new_data, comparison_data) {
   }
   new_data <- convert_to_latin1(new_data)
   comparison_data <- convert_to_latin1(comparison_data)
+
+  # Store original comparison_data for debugging
+  fixed_data <<- comparison_data
 
   # Get numerical variable names
   numeric_var_list <- as.character(std_names_list$Name[which(std_names_list$Type == "numeric")])
@@ -78,13 +220,13 @@ compare_dataframes <- function(new_data, comparison_data) {
   comparison_data <- comparison_data[, !colnames(comparison_data) %in% c("user", "ncdrisc_version"), drop = FALSE]
 
   # Compare row counts
-  new_row_count <- nrow(new_data)
-  old_row_count <- nrow(comparison_data)
+  new_total <- nrow(new_data)
+  old_total <- nrow(comparison_data)
 
-  if (new_row_count != old_row_count) {
+  if (new_total != old_total) {
     any_change_found <- TRUE
     print_it("CAUTION - inconsistent number of rows:", "br_violet")
-    print_it(paste("New:", new_row_count, "vs Old:", old_row_count), indent = 2)
+    print_it(paste("New:", new_total, "vs Old:", old_total), indent = 2)
   }
 
   # Identify columns that are new or have been removed
@@ -109,155 +251,59 @@ compare_dataframes <- function(new_data, comparison_data) {
     print_it(removed_columns, indent = 2)
   }
 
-  # Order datasets before value-by-value comparison
-  id_column <- "id"
+  # Match rows: try id first
+  new_id_df <- data.frame(id = new_data[["id"]], .new_idx = seq_len(new_total))
+  old_id_df <- data.frame(id = comparison_data[["id"]], .old_idx = seq_len(old_total))
 
-  if (id_column %in% colnames(new_data) && id_column %in% colnames(comparison_data)) {
-    # Both datasets have ID columns - check if IDs match
-    new_ids <- sort(new_data[[id_column]])
-    old_ids <- sort(comparison_data[[id_column]])
+  match_result <- match_rows(new_id_df, old_id_df, matching_options[["id"]], "id", new_total, old_total, fail_threshold = 0.1)
 
-    # Determine sorting strategy
-    new_data_ordered <- NULL
-    comparison_data_ordered <- NULL
+  # If id matching failed, try matching based on sample weight, age, sex, and height
+  if (is.null(match_result)) {
+    fallback_type <- names(matching_options)[2]
+    print_it(paste("Trying to match based on", fallback_type), "yellow")
 
-    if (identical(new_ids, old_ids)) {
-      # STRATEGY A: Sort by ID order
-      new_data_ordered <- new_data[order(new_data[[id_column]]), ]
-      comparison_data_ordered <- comparison_data[order(comparison_data[[id_column]]), ]
+    match_columns <- intersect(matching_options[[fallback_type]], intersect(colnames(new_data), colnames(comparison_data)))
 
-    } else {
-      # IDs do not match
-      if (new_row_count != old_row_count) {
-        print_it("CAUTION - IDs do not fully match (the number of rows is different)", "br_violet")
-      } else {
-        print_it("CAUTION - IDs do not match", "br_violet")
-      }
-
-      # Check if value matching should proceed
-      if (max(new_row_count, old_row_count) > 10000) {
-        user_input <- readline(prompt = "Do you want to match on values? It could take a long time (y/n): ")
-        if (tolower(user_input) != "y") {
-          return(any_change_found)
-        }
-      }
-
-      print_it("Trying to match on values...", "yellow")
-
-      # STRATEGY B: Fall back to sorting by columns with matching means
-      common_columns <- intersect(colnames(new_data), colnames(comparison_data))
-      matching_mean_columns <- c()
-
-      for (column_name in common_columns) {
-        if (is.numeric(new_data[[column_name]]) && is.numeric(comparison_data[[column_name]])) {
-          new_mean <- mean(new_data[[column_name]], na.rm = TRUE)
-          old_mean <- mean(comparison_data[[column_name]], na.rm = TRUE)
-          mean_diff <- abs(new_mean - old_mean)
-
-          if (mean_diff == 0) {
-            matching_mean_columns <- c(matching_mean_columns, column_name)
-          }
-        }
-      }
-
-      if (length(matching_mean_columns) > 0) {
-        new_data_ordered <- new_data[do.call(order, new_data[matching_mean_columns]), ]
-        comparison_data_ordered <- comparison_data[do.call(order, comparison_data[matching_mean_columns]), ]
-      }
+    if (length(match_columns) == 0) {
+      print_it(paste("No matching possible based on", fallback_type), "br_red")
+      return(any_change_found)
     }
 
-    # Perform value-by-value comparison
-    if (!is.null(new_data_ordered) && !is.null(comparison_data_ordered)) {
-      # Get columns that exist in both datasets for comparison
-      common_columns <- intersect(colnames(new_data_ordered), colnames(comparison_data_ordered))
-      min_length <- min(nrow(new_data_ordered), nrow(comparison_data_ordered))
-
-      # Compare each common column value-by-value
-      for (column_name in common_columns) {
-        new_column_data <- new_data_ordered[[column_name]][1:min_length]
-        old_column_data <- comparison_data_ordered[[column_name]][1:min_length]
-
-        # Standardize data types for this column based on std_names_list
-        if (column_name %in% numeric_var_list) {
-          new_column_data <- as.numeric(new_column_data)
-          old_column_data <- as.numeric(old_column_data)
+    round_column <- function(df, col) {
+      if (is.numeric(df[[col]])) {
+        if (col %in% c("height", "height1", "height2", "height3")) {
+          return(round(df[[col]], 0))
         } else {
-          if (!is.character(new_column_data)) {
-            new_column_data <- as.character(new_column_data)
-          }
-          if (!is.character(old_column_data)) {
-            old_column_data <- as.character(old_column_data)
-          }
-        }
-
-        # Count changes from or to NA
-        na_to_nonNA_indices <- which(!is.na(new_column_data) & is.na(old_column_data))
-        if (length(na_to_nonNA_indices) > 0) {
-          any_change_found <- TRUE
-          print_it(paste("CAUTION -", length(na_to_nonNA_indices), "NA values changed to non-NA in column", column_name), "br_violet")
-          # Show unique new values and their counts
-          new_values_from_na <- new_column_data[na_to_nonNA_indices]
-          unique_new_values <- unique(new_values_from_na)
-          for (value in unique_new_values[1:min(5, length(unique_new_values))]) {
-            value_count <- sum(new_values_from_na == value, na.rm = TRUE)
-            print_it(paste("NA ->", value, paste0("(", value_count), "cases)"), indent = 2)
-          }
-        }
-        nonNA_to_na_indices <- which(is.na(new_column_data) & !is.na(old_column_data))
-        if (length(nonNA_to_na_indices) > 0) {
-          any_change_found <- TRUE
-          print_it(paste("CAUTION -", length(nonNA_to_na_indices), "non-NA values changed to NA in column", column_name), "br_violet")
-          # Show unique old values and their counts
-          old_values_to_na <- old_column_data[nonNA_to_na_indices]
-          unique_old_values <- unique(old_values_to_na)
-          for (value in unique_old_values[1:min(5, length(unique_old_values))]) {
-            value_count <- sum(old_values_to_na == value, na.rm = TRUE)
-            print_it(paste(value, "-> NA", paste0("(", value_count), "cases)"), indent = 2)
-          }
-        }
-
-        both_not_na <- !is.na(new_column_data) & !is.na(old_column_data)
-        if (sum(both_not_na) > 0) {
-
-          # Check type changes
-          new_is_numeric <- is.numeric(new_column_data)
-          old_is_numeric <- is.numeric(old_column_data)
-
-          if (new_is_numeric && !old_is_numeric) {
-            any_change_found <- TRUE
-            stop(paste("ERROR - Column", column_name, "has incompatible data types: new data is numeric but old data is not"))
-          } else if (!new_is_numeric && old_is_numeric) {
-            any_change_found <- TRUE
-            stop(paste("ERROR - Column", column_name, "has incompatible data types: new data is not numeric but old data is numeric"))
-          }
-
-          # Count value differences (excluding changes from or to NA)
-          value_diff_indices <- c()
-
-          if (new_is_numeric && old_is_numeric) {
-            # Both numeric: precision tolerance
-            value_diff_indices <- which(both_not_na & abs(new_column_data - old_column_data) > 1e-6)
-          } else if (!new_is_numeric && !old_is_numeric) {
-            # Both non-numeric: exact comparison
-            value_diff_indices <- which(both_not_na & new_column_data != old_column_data)
-          }
-
-          if (length(value_diff_indices) > 0) {
-            any_change_found <- TRUE
-            print_it(paste("CAUTION -", length(value_diff_indices), "values changed in", column_name), "br_violet")
-
-            # Show unique cases and their counts
-            old_values <- old_column_data[value_diff_indices]
-            new_values <- new_column_data[value_diff_indices]
-            unique_changes <- unique(paste(old_values, "->", new_values))
-            for (change in unique_changes[1:min(5, length(unique_changes))]) {
-              change_count <- sum(paste(old_values, "->", new_values) == change)
-              print_it(paste(change, paste0("(", change_count), "cases)"), indent = 2)
-            }
-          }
+          return(round(df[[col]]))
         }
       }
+      return(df[[col]])
     }
+
+    new_match_df <- data.frame(lapply(match_columns, function(k) round_column(new_data, k)))
+    old_match_df <- data.frame(lapply(match_columns, function(k) round_column(comparison_data, k)))
+    colnames(new_match_df) <- match_columns
+    colnames(old_match_df) <- match_columns
+    new_match_df$.new_idx <- seq_len(new_total)
+    old_match_df$.old_idx <- seq_len(old_total)
+
+    match_result <- match_rows(new_match_df, old_match_df, match_columns, fallback_type, new_total, old_total, fail_threshold = 0.1)
+
+    if (is.null(match_result)) {
+      return(any_change_found)
+    }
+  }
+
+  if (match_result$any_change_found) {
+    any_change_found <- TRUE
+  }
+
+  # Subset to matched rows and compare values
+  new_data_matched <- new_data[match_result$new_idx, ]
+  old_data_matched <- comparison_data[match_result$old_idx, ]
+
+  if (compare_values(new_data_matched, old_data_matched, match_result$matched_on, match_result$match_columns, numeric_var_list)) {
+    any_change_found <- TRUE
   }
 
   return(any_change_found)

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -133,17 +133,15 @@ compare_dataframes <- function(new_data, old_data) {
     }
   }
   
-  new_for_matching <- new_data[, columns_for_matching, drop = FALSE]
-  new_for_matching$new_row_index <- seq_len(nrow(new_data))
+  # Semi-join: keep only rows in new_data that have a match in old_data, and vice versa
+  new_keys <- do.call(paste, new_data[, columns_for_matching, drop = FALSE])
+  old_keys <- do.call(paste, old_data[, columns_for_matching, drop = FALSE])
 
-  old_for_matching <- old_data[, columns_for_matching, drop = FALSE]
-  old_for_matching$old_row_index <- seq_len(nrow(old_data))
+  new_in_old <- new_keys %in% old_keys
+  old_in_new <- old_keys %in% new_keys
 
-  matched_data <- merge(new_for_matching, old_for_matching, by = columns_for_matching, all.x = TRUE)
-  print_it(paste("Merge result:", nrow(matched_data), "rows |", sum(!is.na(matched_data$old_row_index)), "matched |", sum(is.na(matched_data$old_row_index)), "unmatched"), "yellow")
-
-  new_rows <- sum(is.na(matched_data$old_row_index))
-  removed_rows <- nrow(old_data) - length(unique(na.omit(matched_data$old_row_index)))
+  new_rows <- sum(!new_in_old)
+  removed_rows <- sum(!old_in_new)
   if (new_rows > 0) {
     any_change <- TRUE
     print_it(paste("CAUTION -", new_rows, "added rows"), "br_violet")
@@ -153,42 +151,52 @@ compare_dataframes <- function(new_data, old_data) {
     print_it(paste("CAUTION -", removed_rows, "removed rows"), "br_violet")
   }
 
-  matched_data <- matched_data[!is.na(matched_data$old_row_index), ]
+  new_data_matched <- new_data[new_in_old, ]
+  old_data_matched <- old_data[old_in_new, ]
 
-  print_it(paste("Comparing", nrow(matched_data), "rows across", length(common_columns), "columns"), "yellow")
+  # Sort both by matching columns
+  new_data_matched <- new_data_matched[do.call(order, new_data_matched[, columns_for_matching, drop = FALSE]), ]
+  old_data_matched <- old_data_matched[do.call(order, old_data_matched[, columns_for_matching, drop = FALSE]), ]
 
-  new_data_matched <- new_data[matched_data$new_row_index, ]
-  old_data_matched <- old_data[matched_data$old_row_index, ]
+  print_it(paste("Comparing", nrow(new_data_matched), "rows across", length(common_columns), "columns"), "yellow")
 
-  for (column in common_columns) {
-    new_values <- new_data_matched[[column]]
-    old_values <- old_data_matched[[column]]
+  # Compare each common column value-by-value
+  for (column_name in common_columns) {
+    new_column_data <- new_data_matched[[column_name]]
+    old_column_data <- old_data_matched[[column_name]]
 
-    if (column %in% numeric_columns) {
-      new_values <- as.numeric(new_values)
-      old_values <- as.numeric(old_values)
+    # Standardize data types for this column based on std_names_list
+    if (column_name %in% numeric_columns) {
+      new_column_data <- as.numeric(new_column_data)
+      old_column_data <- as.numeric(old_column_data)
     } else {
-      if (!is.character(new_values)) new_values <- as.character(new_values)
-      if (!is.character(old_values)) old_values <- as.character(old_values)
+      if (!is.character(new_column_data)) {
+        new_column_data <- as.character(new_column_data)
+      }
+      if (!is.character(old_column_data)) {
+        old_column_data <- as.character(old_column_data)
+      }
     }
 
     # Count changes from or to NA
-    na_to_nonNA_indices <- which(!is.na(new_values) & is.na(old_values))
+    na_to_nonNA_indices <- which(!is.na(new_column_data) & is.na(old_column_data))
     if (length(na_to_nonNA_indices) > 0) {
       any_change <- TRUE
-      print_it(paste("CAUTION -", length(na_to_nonNA_indices), "NA values changed to non-NA in column", column), "br_violet")
-      new_values_from_na <- new_values[na_to_nonNA_indices]
+      print_it(paste("CAUTION -", length(na_to_nonNA_indices), "NA values changed to non-NA in column", column_name), "br_violet")
+      # Show unique new values and their counts
+      new_values_from_na <- new_column_data[na_to_nonNA_indices]
       unique_new_values <- unique(new_values_from_na)
       for (value in unique_new_values[1:min(5, length(unique_new_values))]) {
         value_count <- sum(new_values_from_na == value, na.rm = TRUE)
         print_it(paste("NA ->", value, paste0("(", value_count), "cases)"), indent = 2)
       }
     }
-    nonNA_to_na_indices <- which(is.na(new_values) & !is.na(old_values))
+    nonNA_to_na_indices <- which(is.na(new_column_data) & !is.na(old_column_data))
     if (length(nonNA_to_na_indices) > 0) {
       any_change <- TRUE
-      print_it(paste("CAUTION -", length(nonNA_to_na_indices), "non-NA values changed to NA in column", column), "br_violet")
-      old_values_to_na <- old_values[nonNA_to_na_indices]
+      print_it(paste("CAUTION -", length(nonNA_to_na_indices), "non-NA values changed to NA in column", column_name), "br_violet")
+      # Show unique old values and their counts
+      old_values_to_na <- old_column_data[nonNA_to_na_indices]
       unique_old_values <- unique(old_values_to_na)
       for (value in unique_old_values[1:min(5, length(unique_old_values))]) {
         value_count <- sum(old_values_to_na == value, na.rm = TRUE)
@@ -196,27 +204,48 @@ compare_dataframes <- function(new_data, old_data) {
       }
     }
 
-    both_not_na <- !is.na(new_values) & !is.na(old_values)
-    if (sum(both_not_na) == 0) next
+    both_not_na <- !is.na(new_column_data) & !is.na(old_column_data)
+    if (sum(both_not_na) > 0) {
 
-    value_diff_indices <- c()
-    if (is.numeric(new_values)) {
-      value_diff_indices <- which(both_not_na & abs(new_values - old_values) > 1e-6)
-    } else {
-      for (i in which(both_not_na)) {
-        if (new_values[i] != old_values[i]) {
-          value_diff_indices <- c(value_diff_indices, i)
+      # Check type changes
+      new_is_numeric <- is.numeric(new_column_data)
+      old_is_numeric <- is.numeric(old_column_data)
+
+      if (new_is_numeric && !old_is_numeric) {
+        any_change <- TRUE
+        stop(paste("ERROR - Column", column_name, "has incompatible data types: new data is numeric but old data is not"))
+      } else if (!new_is_numeric && old_is_numeric) {
+        any_change <- TRUE
+        stop(paste("ERROR - Column", column_name, "has incompatible data types: new data is not numeric but old data is numeric"))
+      }
+
+      # Count value differences (excluding changes from or to NA)
+      value_diff_indices <- c()
+
+      if (new_is_numeric && old_is_numeric) {
+        # Both numeric: precision tolerance
+        value_diff_indices <- which(both_not_na & abs(new_column_data - old_column_data) > 1e-6)
+      } else if (!new_is_numeric && !old_is_numeric) {
+        # Both non-numeric: exact comparison
+        for (i in which(both_not_na)) {
+          if (new_column_data[i] != old_column_data[i]) {
+            value_diff_indices <- c(value_diff_indices, i)
+          }
         }
       }
-    }
 
-    if (length(value_diff_indices) > 0) {
-      any_change <- TRUE
-      print_it(paste("CAUTION -", length(value_diff_indices), "values changed in", column), "br_violet")
-      unique_changes <- unique(paste(old_values[value_diff_indices], "->", new_values[value_diff_indices]))
-      for (change in unique_changes[1:min(5, length(unique_changes))]) {
-        change_count <- sum(paste(old_values[value_diff_indices], "->", new_values[value_diff_indices]) == change)
-        print_it(paste(change, paste0("(", change_count), "cases)"), indent = 2)
+      if (length(value_diff_indices) > 0) {
+        any_change <- TRUE
+        print_it(paste("CAUTION -", length(value_diff_indices), "values changed in", column_name), "br_violet")
+
+        # Show unique cases and their counts
+        old_values <- old_column_data[value_diff_indices]
+        new_values <- new_column_data[value_diff_indices]
+        unique_changes <- unique(paste(old_values, "->", new_values))
+        for (change in unique_changes[1:min(5, length(unique_changes))]) {
+          change_count <- sum(paste(old_values, "->", new_values) == change)
+          print_it(paste(change, paste0("(", change_count), "cases)"), indent = 2)
+        }
       }
     }
   }

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -112,14 +112,20 @@ compare_dataframes <- function(new_data, old_data) {
 
   } else {
     # Find columns that uniquely identify rows in old_data
+    # Only use numeric columns and exclude "id"
     print_it("Finding columns for matching...", "yellow")
+
+    available_columns <- common_columns[common_columns %in% numeric_var_list & common_columns != "id"]
+    print_it(paste("Numeric columns available:", length(numeric_columns)), "yellow")
+
     columns_for_matching <- c()
     done <- FALSE
 
-    for (column in common_columns) {
+    for (column in available_columns) {
       columns_for_matching <- c(columns_for_matching, column)
+      current_subset <- old_data[, columns_for_matching, drop = FALSE]
 
-      if (anyDuplicated(old_data[, columns_for_matching, drop = FALSE]) == 0) {
+      if (anyDuplicated(current_subset) == 0) {
         done <- TRUE
         print_it(paste("Using columns:", paste(columns_for_matching, collapse = ", ")), "yellow")
         break
@@ -128,6 +134,8 @@ compare_dataframes <- function(new_data, old_data) {
 
     if (!done) {
       print_it("Could not automatically match rows", "br_red")
+      print_it("Saving last subset to 'debug_matching_subset' for inspection", "yellow")
+      debug_matching_subset <<- current_subset
       return(any_change)
     }
   }

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -130,17 +130,25 @@ compare_dataframes <- function(new_data, old_data) {
       return(any_change)
     }
   }
-
+  
   new_for_matching <- new_data[, columns_for_matching, drop = FALSE]
-  new_for_matching$new_row_index <- seq_len(new_total)
+  new_for_matching$new_row_index <- seq_len(nrow(new_data))
 
   old_for_matching <- old_data[, columns_for_matching, drop = FALSE]
-  old_for_matching$old_row_index <- seq_len(old_total)
+  old_for_matching$old_row_index <- seq_len(nrow(old_data))
 
   matched_data <- merge(new_for_matching, old_for_matching, by = columns_for_matching, all.x = TRUE)
 
   new_rows <- sum(is.na(matched_data$old_row_index))
-  if (new_rows > 0) print_it(paste(new_rows, "new rows"), "yellow")
+  removed_rows <- nrow(old_data) - length(unique(na.omit(matched_data$old_row_index)))
+  if (new_rows > 0) {
+    any_change <- TRUE
+    print_it(paste("CAUTION -", new_rows, "added rows"), "br_violet")
+  }
+  if (removed_rows > 0) {
+    any_change <- TRUE
+    print_it(paste("CAUTION -", removed_rows, "removed rows"), "br_violet")
+  }
 
   matched_data <- matched_data[!is.na(matched_data$old_row_index), ]
   columns_to_compare <- intersect(colnames(new_data), colnames(old_data))

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -20,8 +20,8 @@ read_extracted_df <- function(filename, target_dir = NULL) {
   # Check if CSV file exists
   if (file.exists(csv_path)) {
     tryCatch({
-      df_latin1 <- read.csv(csv_path, fileEncoding = "latin1")
-      df_utf8 <- read.csv(csv_path, fileEncoding = "UTF-8")
+      df_latin1 <- suppressWarnings(read.csv(csv_path, fileEncoding = "latin1"))
+      df_utf8 <- suppressWarnings(read.csv(csv_path, fileEncoding = "UTF-8"))
       
       if (nrow(df_utf8) > nrow(df_latin1)) {
         return(df_utf8)

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -159,19 +159,19 @@ compare_dataframes <- function(new_data, comparison_data) {
     print_it(paste("CAUTION -", removed_rows, "removed rows"), "br_violet")
   }
 
-  new_data_matched <- new_data[new_in_old, ]
-  comparison_data_matched <- comparison_data[old_in_new, ]
+  new_data_ordered <- new_data[new_in_old, ]
+  comparison_data_ordered <- comparison_data[old_in_new, ]
 
   # Sort both by matching columns
-  new_data_matched <- new_data_matched[do.call(order, new_data_matched[, columns_for_matching, drop = FALSE]), ]
-  comparison_data_matched <- comparison_data_matched[do.call(order, comparison_data_matched[, columns_for_matching, drop = FALSE]), ]
+  new_data_ordered <- new_data_ordered[do.call(order, new_data_ordered[, columns_for_matching, drop = FALSE]), ]
+  comparison_data_ordered <- comparison_data_ordered[do.call(order, comparison_data_ordered[, columns_for_matching, drop = FALSE]), ]
 
-  print_it(paste("Comparing", nrow(new_data_matched), "rows across", length(common_columns), "columns"), "yellow")
+  print_it(paste("Comparing", nrow(new_data_ordered), "rows across", length(common_columns), "columns"), "yellow")
 
       # Compare each common column value-by-value
       for (column_name in common_columns) {
-        new_column_data <- new_data_matched[[column_name]]
-        old_column_data <- comparison_data_matched[[column_name]]
+        new_column_data <- new_data_ordered[[column_name]]
+        old_column_data <- comparison_data_ordered[[column_name]]
 
         # Standardize data types for this column based on std_names_list
         if (column_name %in% numeric_var_list) {

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -86,8 +86,8 @@ compare_dataframes <- function(new_data, old_data) {
   }
 
   # Ask user how to match rows
-  choice <- menu(c("id (use if id column has not changed)",
-                   "auto (use if id column has changed)"),
+  choice <- menu(c("id (use if there is a common id column in the data being extracted and in the previous extraction)",
+                   "auto (use if there is no common id column; may be slow with >100,000 rows)"),
                  title = "How to match rows:")
   
   common_columns <- intersect(colnames(old_data), colnames(new_data))
@@ -103,32 +103,32 @@ compare_dataframes <- function(new_data, old_data) {
 
   } else {
     # Find columns that uniquely identify rows in old_data
-    # Only use numeric columns and exclude "id"
+    # Exclude "id" and metadata columns
     print_it("Finding columns for matching...", "yellow")
 
-    available_columns <- common_columns[common_columns %in% numeric_var_list & common_columns != "id"]
+    available_columns <- common_columns[common_columns != "id"]
+    available_columns <- available_columns[!grepl("^age_min_|^age_max_|^is_|_year$", available_columns)]
+    available_columns <- available_columns[available_columns %in% numeric_var_list]
     print_it(paste("Numeric columns available:", paste(available_columns, collapse = ", ")), "yellow")
 
     columns_for_matching <- c()
     done <- FALSE
-    step <- 4
 
-    for (i in seq(1, length(available_columns), by = step)) {
-      batch <- available_columns[i:min(i + step - 1, length(available_columns))]
-      columns_for_matching <- c(columns_for_matching, batch)
-      print_it(paste("Adding:", paste(batch, collapse = ", ")), "yellow")
+    for (column in available_columns) {
+      columns_for_matching <- c(columns_for_matching, column)
       current_subset <- old_data[, columns_for_matching, drop = FALSE]
 
       if (anyDuplicated(current_subset) == 0) {
         done <- TRUE
-        print_it(paste("Using columns:", paste(columns_for_matching, collapse = ", ")), "yellow")
         break
       }
     }
 
     if (!done) {
-      print_it("Could not automatically match rows", "br_red")
-      print_it("Saving last subset to 'debug_matching_subset' for inspection", "yellow")
+      print_it("Could not automatically match rows - rows are not unique", "br_red")
+      print_it("This can be expected with large datasets (>100,000 rows)", indent = 2)
+      print_it("If that is not the case, please check if having duplicate rows in the data being extracted is expected", indent = 2)
+      print_it("If there is no common id column and automatic matching fails, consistency with previous extraction should be carefully checked manually", indent = 2)
       debug_matching_subset <<- current_subset
       return(any_change)
     }

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -21,7 +21,7 @@ read_extracted_df <- function(filename, target_dir = NULL) {
   if (file.exists(csv_path)) {
     tryCatch({
       df_latin1 <- read.csv(csv_path, fileEncoding = "latin1")
-      df_utf8 <- read.csv(csv_path)
+      df_utf8 <- read.csv(csv_path, fileEncoding = "UTF-8")
 
       if (nrow(df_latin1) != nrow(df_utf8)) {
         print_it("(read as UTF-8)", "yellow")
@@ -51,16 +51,17 @@ compare_dataframes <- function(new_data, comparison_data) {
   # flag for if any change was found
   any_change_found <- FALSE
   
-  # Convert character columns to UTF-8 for consistent comparison
-  convert_to_utf8 <- function(df) {
-    df[] <- lapply(df, function(x) {
-      if (is.character(x)) enc2utf8(x)
-      else x
-    })
+  # Convert character columns to latin1 for consistent comparison
+  convert_to_latin1 <- function(df) {
+    for (col in names(df)) {
+      if (is.character(df[[col]])) {
+        df[[col]] <- iconv(df[[col]], from = "UTF-8", to = "latin1", sub = "")
+      }
+    }
     return(df)
   }
-  new_data <- convert_to_utf8(new_data)
-  comparison_data <- convert_to_utf8(comparison_data)
+  new_data <- convert_to_latin1(new_data)
+  comparison_data <- convert_to_latin1(comparison_data)
 
   # Get numerical variable names
   numeric_var_list <- as.character(std_names_list$Name[which(std_names_list$Type == "numeric")])

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -53,10 +53,10 @@ compare_dataframes <- function(new_data, comparison_data) {
 
   # Convert character columns to latin1
   for (col in names(new_data)) {
-    if (is.character(new_data[[col]])) new_data[[col]] <- suppressWarnings(iconv(new_data[[col]], from = "UTF-8", to = "latin1", sub = ""))
+    if (is.character(new_data[[col]])) new_data[[col]] <- iconv(new_data[[col]], from = "UTF-8", to = "latin1", sub = "")
   }
   for (col in names(comparison_data)) {
-    if (is.character(comparison_data[[col]])) comparison_data[[col]] <- suppressWarnings(iconv(comparison_data[[col]], from = "UTF-8", to = "latin1", sub = ""))
+    if (is.character(comparison_data[[col]])) comparison_data[[col]] <- iconv(comparison_data[[col]], from = "UTF-8", to = "latin1", sub = "")
   }
   # Remove fully empty columns from both datasets
   new_data_non_empty_cols <- sapply(new_data, function(col) !all(is.na(col)))

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -46,43 +46,51 @@ read_extracted_df <- function(filename, target_dir = NULL) {
 #' - matches data line-by-line and compares every value.
 #'
 #' @param new_data data frame of the data being extracted
-#' @param old_data data frame of previously extracted data
-compare_dataframes <- function(new_data, old_data) {
+#' @param comparison_data data frame of previously extracted data
+compare_dataframes <- function(new_data, comparison_data) {
 
-  any_change <- FALSE
+  any_change_found <- FALSE
 
   # Convert character columns to latin1
   for (col in names(new_data)) {
     if (is.character(new_data[[col]])) new_data[[col]] <- iconv(new_data[[col]], from = "UTF-8", to = "latin1", sub = "")
   }
-  for (col in names(old_data)) {
-    if (is.character(old_data[[col]])) old_data[[col]] <- iconv(old_data[[col]], from = "UTF-8", to = "latin1", sub = "")
+  for (col in names(comparison_data)) {
+    if (is.character(comparison_data[[col]])) comparison_data[[col]] <- iconv(comparison_data[[col]], from = "UTF-8", to = "latin1", sub = "")
   }
-  # Remove fully empty columns
-  new_data <- new_data[, sapply(new_data, function(x) !all(is.na(x))), drop = FALSE]
-  old_data <- old_data[, sapply(old_data, function(x) !all(is.na(x))), drop = FALSE]
+  # Remove fully empty columns from both datasets
+  new_data_non_empty_cols <- sapply(new_data, function(col) !all(is.na(col)))
+  comparison_non_empty_cols <- sapply(comparison_data, function(col) !all(is.na(col)))
+
+  new_data <- new_data[, new_data_non_empty_cols, drop = FALSE]
+  comparison_data <- comparison_data[, comparison_non_empty_cols, drop = FALSE]
 
   # Remove user and ncdrisc_version columns from old data
   # These are written when calling save_extraction()
-  old_data <- old_data[, !colnames(old_data) %in% c("user", "ncdrisc_version"), drop = FALSE]
+  comparison_data <- comparison_data[, !colnames(comparison_data) %in% c("user", "ncdrisc_version"), drop = FALSE]
 
   std_names_list <- ncdrisc::std_names_list
-  common_columns <- intersect(colnames(new_data), colnames(old_data))
-  numeric_columns <- as.character(std_names_list$Name[which(std_names_list$Type == "numeric")])
+  common_columns <- intersect(colnames(new_data), colnames(comparison_data))
+  numeric_var_list <- as.character(std_names_list$Name[which(std_names_list$Type == "numeric")])
 
-  # Compare column names
-  new_cols <- setdiff(colnames(new_data), colnames(old_data))
-  removed_cols <- setdiff(colnames(old_data), colnames(new_data))
-  if (length(new_cols) > 0) {
-    any_change <- TRUE
-    print_it("CAUTION - Added columns:", "br_violet")
-    print_it(new_cols, indent = 2)
-    added_columns <<- new_data[, new_cols, drop = FALSE]
+  # Identify columns that are new or have been removed
+  new_file_columns <- colnames(new_data)
+  old_file_columns <- colnames(comparison_data)
+
+  new_columns <- setdiff(new_file_columns, old_file_columns)
+  removed_columns <- setdiff(old_file_columns, new_file_columns)
+  if (length(new_columns) > 0) {
+    any_change_found <- TRUE
+    print_it("CAUTION - added columns:", "br_violet")
+    print_it(new_columns, indent = 2)
+
+    # Save added columns dataframe to workspace to then run summary(added_columns) from the main script
+    added_columns <<- new_data[, new_columns, drop = FALSE]
   }
-  if (length(removed_cols) > 0) {
-    any_change <- TRUE
-    print_it("CAUTION - Removed columns:", "br_violet")
-    print_it(removed_cols, indent = 2)
+  if (length(removed_columns) > 0) {
+    any_change_found <- TRUE
+    print_it("CAUTION - removed columns:", "br_violet")
+    print_it(removed_columns, indent = 2)
   }
 
   # Ask user how to match rows
@@ -94,12 +102,12 @@ compare_dataframes <- function(new_data, old_data) {
     # Match by id
     if (!"id" %in% common_columns) {
       print_it("No id column found", "br_red")
-      return(any_change)
+      return(any_change_found)
     }
     columns_for_matching <- "id"
-    print_it(paste("Matching by id | new id class:", class(new_data$id), "| old id class:", class(old_data$id)), "yellow")
+    print_it(paste("Matching by id | new id class:", class(new_data$id), "| old id class:", class(comparison_data$id)), "yellow")
     print_it(paste("new ids sample:", paste(head(new_data$id, 3), collapse=", ")), "yellow")
-    print_it(paste("old ids sample:", paste(head(old_data$id, 3), collapse=", ")), "yellow")
+    print_it(paste("old ids sample:", paste(head(comparison_data$id, 3), collapse=", ")), "yellow")
 
   } else {
     # Find columns that uniquely identify rows
@@ -107,7 +115,7 @@ compare_dataframes <- function(new_data, old_data) {
 
     available_columns <- common_columns[common_columns != "id"]
     available_columns <- available_columns[!grepl("^age_min_|^age_max_|^is_|_year$", available_columns)]
-    available_columns <- available_columns[available_columns %in% numeric_columns]
+    available_columns <- available_columns[available_columns %in% numeric_var_list]
     print_it(paste("Numeric columns available:", paste(available_columns, collapse = ", ")), "yellow")
 
     columns_for_matching <- c()
@@ -115,7 +123,7 @@ compare_dataframes <- function(new_data, old_data) {
 
     for (column in available_columns) {
       columns_for_matching <- c(columns_for_matching, column)
-      current_subset <- old_data[, columns_for_matching, drop = FALSE]
+      current_subset <- comparison_data[, columns_for_matching, drop = FALSE]
 
       if (anyDuplicated(current_subset) == 0) {
         done <- TRUE
@@ -129,13 +137,13 @@ compare_dataframes <- function(new_data, old_data) {
       print_it("If that is not the case, please check if having duplicate rows in the data being extracted is expected", indent = 2)
       print_it("If there is no common id column and automatic matching fails, consistency with previous extraction should be carefully checked manually", indent = 2)
       debug_matching_subset <<- current_subset
-      return(any_change)
+      return(any_change_found)
     }
   }
   
-  # Semi-join: keep only rows in new_data that have a match in old_data, and vice versa
+  # Semi-join: keep only rows in new_data that have a match in comparison_data, and vice versa
   new_keys <- do.call(paste, new_data[, columns_for_matching, drop = FALSE])
-  old_keys <- do.call(paste, old_data[, columns_for_matching, drop = FALSE])
+  old_keys <- do.call(paste, comparison_data[, columns_for_matching, drop = FALSE])
 
   new_in_old <- new_keys %in% old_keys
   old_in_new <- old_keys %in% new_keys
@@ -143,30 +151,30 @@ compare_dataframes <- function(new_data, old_data) {
   new_rows <- sum(!new_in_old)
   removed_rows <- sum(!old_in_new)
   if (new_rows > 0) {
-    any_change <- TRUE
+    any_change_found <- TRUE
     print_it(paste("CAUTION -", new_rows, "added rows"), "br_violet")
   }
   if (removed_rows > 0) {
-    any_change <- TRUE
+    any_change_found <- TRUE
     print_it(paste("CAUTION -", removed_rows, "removed rows"), "br_violet")
   }
 
   new_data_matched <- new_data[new_in_old, ]
-  old_data_matched <- old_data[old_in_new, ]
+  comparison_data_matched <- comparison_data[old_in_new, ]
 
   # Sort both by matching columns
   new_data_matched <- new_data_matched[do.call(order, new_data_matched[, columns_for_matching, drop = FALSE]), ]
-  old_data_matched <- old_data_matched[do.call(order, old_data_matched[, columns_for_matching, drop = FALSE]), ]
+  comparison_data_matched <- comparison_data_matched[do.call(order, comparison_data_matched[, columns_for_matching, drop = FALSE]), ]
 
   print_it(paste("Comparing", nrow(new_data_matched), "rows across", length(common_columns), "columns"), "yellow")
 
   # Compare each common column value-by-value
   for (column_name in common_columns) {
     new_column_data <- new_data_matched[[column_name]]
-    old_column_data <- old_data_matched[[column_name]]
+    old_column_data <- comparison_data_matched[[column_name]]
 
     # Standardize data types for this column based on std_names_list
-    if (column_name %in% numeric_columns) {
+    if (column_name %in% numeric_var_list) {
       new_column_data <- as.numeric(new_column_data)
       old_column_data <- as.numeric(old_column_data)
     } else {
@@ -181,7 +189,7 @@ compare_dataframes <- function(new_data, old_data) {
     # Count changes from or to NA
     na_to_nonNA_indices <- which(!is.na(new_column_data) & is.na(old_column_data))
     if (length(na_to_nonNA_indices) > 0) {
-      any_change <- TRUE
+      any_change_found <- TRUE
       print_it(paste("CAUTION -", length(na_to_nonNA_indices), "NA values changed to non-NA in column", column_name), "br_violet")
       # Show unique new values and their counts
       new_values_from_na <- new_column_data[na_to_nonNA_indices]
@@ -193,7 +201,7 @@ compare_dataframes <- function(new_data, old_data) {
     }
     nonNA_to_na_indices <- which(is.na(new_column_data) & !is.na(old_column_data))
     if (length(nonNA_to_na_indices) > 0) {
-      any_change <- TRUE
+      any_change_found <- TRUE
       print_it(paste("CAUTION -", length(nonNA_to_na_indices), "non-NA values changed to NA in column", column_name), "br_violet")
       # Show unique old values and their counts
       old_values_to_na <- old_column_data[nonNA_to_na_indices]
@@ -212,10 +220,10 @@ compare_dataframes <- function(new_data, old_data) {
       old_is_numeric <- is.numeric(old_column_data)
 
       if (new_is_numeric && !old_is_numeric) {
-        any_change <- TRUE
+        any_change_found <- TRUE
         stop(paste("ERROR - Column", column_name, "has incompatible data types: new data is numeric but old data is not"))
       } else if (!new_is_numeric && old_is_numeric) {
-        any_change <- TRUE
+        any_change_found <- TRUE
         stop(paste("ERROR - Column", column_name, "has incompatible data types: new data is not numeric but old data is numeric"))
       }
 
@@ -231,7 +239,7 @@ compare_dataframes <- function(new_data, old_data) {
       }
 
       if (length(value_diff_indices) > 0) {
-        any_change <- TRUE
+        any_change_found <- TRUE
         print_it(paste("CAUTION -", length(value_diff_indices), "values changed in", column_name), "br_violet")
 
         # Show unique cases and their counts
@@ -246,7 +254,7 @@ compare_dataframes <- function(new_data, old_data) {
     }
   }
 
-  return(any_change)
+  return(any_change_found)
 }
 
 
@@ -269,16 +277,16 @@ check_data_changes <- function(data, filename, study_dir = NULL, extracted_data_
     print_it("Checking changes in data in comparison with the following file...", "yellow")
     print_it(paste0(curr_dir, filename, ".csv"), indent = 2)
 
-    # Load old data using read_extracted_df
-    old_data <- read_extracted_df(filename, curr_dir)
+    # Load comparison data using read_extracted_df
+    comparison_data <- read_extracted_df(filename, curr_dir)
 
-    if (is.null(old_data)) {
+    if (is.null(comparison_data)) {
       print_it(paste("ERROR - file does not exist"), "br_red")
       return(invisible())
     }
 
     # Call compare_dataframes to do the actual comparison
-    found_any <- compare_dataframes(data, old_data)
+    found_any <- compare_dataframes(data, comparison_data)
 
     if (!found_any) print_it("No changes found", "yellow")
 

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -23,6 +23,8 @@ read_extracted_df <- function(filename, target_dir = NULL) {
       df_latin1 <- read.csv(csv_path, fileEncoding = "latin1")
       df_utf8 <- read.csv(csv_path, fileEncoding = "UTF-8")
 
+      print_it(paste("latin1:", nrow(df_latin1), "rows", ncol(df_latin1), "cols | UTF-8:", nrow(df_utf8), "rows", ncol(df_utf8), "cols"), "yellow")
+
       if (nrow(df_latin1) != nrow(df_utf8)) {
         print_it("(read as UTF-8)", "yellow")
         return(df_utf8)

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -50,19 +50,17 @@ compare_dataframes <- function(new_data, comparison_data) {
 
   # flag for if any change was found
   any_change_found <- FALSE
-
-  # Convert both datasets to latin1
-  new_data[] <- lapply(new_data, function(x) {
-    if (is.character(x)) iconv(x, from = "latin1", to = "UTF-8", sub = "")
-    else x
-  })
-  comparison_data[] <- lapply(comparison_data, function(x) {
-    if (is.character(x)) iconv(x, from = "latin1", to = "UTF-8", sub = "")
-    else x
-  })
-
-  # Store original comparison_data for debugging
-  fixed_data <<- comparison_data
+  
+  # Convert character columns to UTF-8 for consistent comparison
+  convert_to_utf8 <- function(df) {
+    df[] <- lapply(df, function(x) {
+      if (is.character(x)) enc2utf8(x)
+      else x
+    })
+    return(df)
+  }
+  new_data <- convert_to_utf8(new_data)
+  comparison_data <- convert_to_utf8(comparison_data)
 
   # Get numerical variable names
   numeric_var_list <- as.character(std_names_list$Name[which(std_names_list$Type == "numeric")])

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -168,91 +168,91 @@ compare_dataframes <- function(new_data, comparison_data) {
 
   print_it(paste("Comparing", nrow(new_data_matched), "rows across", length(common_columns), "columns"), "yellow")
 
-  # Compare each common column value-by-value
-  for (column_name in common_columns) {
-    new_column_data <- new_data_matched[[column_name]]
-    old_column_data <- comparison_data_matched[[column_name]]
+      # Compare each common column value-by-value
+      for (column_name in common_columns) {
+        new_column_data <- new_data_matched[[column_name]]
+        old_column_data <- comparison_data_matched[[column_name]]
 
-    # Standardize data types for this column based on std_names_list
-    if (column_name %in% numeric_var_list) {
-      new_column_data <- as.numeric(new_column_data)
-      old_column_data <- as.numeric(old_column_data)
-    } else {
-      if (!is.character(new_column_data)) {
-        new_column_data <- as.character(new_column_data)
-      }
-      if (!is.character(old_column_data)) {
-        old_column_data <- as.character(old_column_data)
-      }
-    }
+        # Standardize data types for this column based on std_names_list
+        if (column_name %in% numeric_var_list) {
+          new_column_data <- as.numeric(new_column_data)
+          old_column_data <- as.numeric(old_column_data)
+        } else {
+          if (!is.character(new_column_data)) {
+            new_column_data <- as.character(new_column_data)
+          }
+          if (!is.character(old_column_data)) {
+            old_column_data <- as.character(old_column_data)
+          }
+        }
 
-    # Count changes from or to NA
-    na_to_nonNA_indices <- which(!is.na(new_column_data) & is.na(old_column_data))
-    if (length(na_to_nonNA_indices) > 0) {
-      any_change_found <- TRUE
-      print_it(paste("CAUTION -", length(na_to_nonNA_indices), "NA values changed to non-NA in column", column_name), "br_violet")
-      # Show unique new values and their counts
-      new_values_from_na <- new_column_data[na_to_nonNA_indices]
-      unique_new_values <- unique(new_values_from_na)
-      for (value in unique_new_values[1:min(5, length(unique_new_values))]) {
-        value_count <- sum(new_values_from_na == value, na.rm = TRUE)
-        print_it(paste("NA ->", value, paste0("(", value_count), "cases)"), indent = 2)
-      }
-    }
-    nonNA_to_na_indices <- which(is.na(new_column_data) & !is.na(old_column_data))
-    if (length(nonNA_to_na_indices) > 0) {
-      any_change_found <- TRUE
-      print_it(paste("CAUTION -", length(nonNA_to_na_indices), "non-NA values changed to NA in column", column_name), "br_violet")
-      # Show unique old values and their counts
-      old_values_to_na <- old_column_data[nonNA_to_na_indices]
-      unique_old_values <- unique(old_values_to_na)
-      for (value in unique_old_values[1:min(5, length(unique_old_values))]) {
-        value_count <- sum(old_values_to_na == value, na.rm = TRUE)
-        print_it(paste(value, "-> NA", paste0("(", value_count), "cases)"), indent = 2)
-      }
-    }
+        # Count changes from or to NA
+        na_to_nonNA_indices <- which(!is.na(new_column_data) & is.na(old_column_data))
+        if (length(na_to_nonNA_indices) > 0) {
+          any_change_found <- TRUE
+          print_it(paste("CAUTION -", length(na_to_nonNA_indices), "NA values changed to non-NA in column", column_name), "br_violet")
+          # Show unique new values and their counts
+          new_values_from_na <- new_column_data[na_to_nonNA_indices]
+          unique_new_values <- unique(new_values_from_na)
+          for (value in unique_new_values[1:min(5, length(unique_new_values))]) {
+            value_count <- sum(new_values_from_na == value, na.rm = TRUE)
+            print_it(paste("NA ->", value, paste0("(", value_count), "cases)"), indent = 2)
+          }
+        }
+        nonNA_to_na_indices <- which(is.na(new_column_data) & !is.na(old_column_data))
+        if (length(nonNA_to_na_indices) > 0) {
+          any_change_found <- TRUE
+          print_it(paste("CAUTION -", length(nonNA_to_na_indices), "non-NA values changed to NA in column", column_name), "br_violet")
+          # Show unique old values and their counts
+          old_values_to_na <- old_column_data[nonNA_to_na_indices]
+          unique_old_values <- unique(old_values_to_na)
+          for (value in unique_old_values[1:min(5, length(unique_old_values))]) {
+            value_count <- sum(old_values_to_na == value, na.rm = TRUE)
+            print_it(paste(value, "-> NA", paste0("(", value_count), "cases)"), indent = 2)
+          }
+        }
 
-    both_not_na <- !is.na(new_column_data) & !is.na(old_column_data)
-    if (sum(both_not_na) > 0) {
+        both_not_na <- !is.na(new_column_data) & !is.na(old_column_data)
+        if (sum(both_not_na) > 0) {
 
-      # Check type changes
-      new_is_numeric <- is.numeric(new_column_data)
-      old_is_numeric <- is.numeric(old_column_data)
+          # Check type changes
+          new_is_numeric <- is.numeric(new_column_data)
+          old_is_numeric <- is.numeric(old_column_data)
 
-      if (new_is_numeric && !old_is_numeric) {
-        any_change_found <- TRUE
-        stop(paste("ERROR - Column", column_name, "has incompatible data types: new data is numeric but old data is not"))
-      } else if (!new_is_numeric && old_is_numeric) {
-        any_change_found <- TRUE
-        stop(paste("ERROR - Column", column_name, "has incompatible data types: new data is not numeric but old data is numeric"))
-      }
+          if (new_is_numeric && !old_is_numeric) {
+            any_change_found <- TRUE
+            stop(paste("ERROR - Column", column_name, "has incompatible data types: new data is numeric but old data is not"))
+          } else if (!new_is_numeric && old_is_numeric) {
+            any_change_found <- TRUE
+            stop(paste("ERROR - Column", column_name, "has incompatible data types: new data is not numeric but old data is numeric"))
+          }
 
-      # Count value differences (excluding changes from or to NA)
-      value_diff_indices <- c()
+          # Count value differences (excluding changes from or to NA)
+          value_diff_indices <- c()
 
-      if (new_is_numeric && old_is_numeric) {
-        # Both numeric: precision tolerance
-        value_diff_indices <- which(both_not_na & abs(new_column_data - old_column_data) > 1e-6)
-      } else if (!new_is_numeric && !old_is_numeric) {
-        # Both non-numeric: exact comparison
-        value_diff_indices <- which(both_not_na & new_column_data != old_column_data)
-      }
+          if (new_is_numeric && old_is_numeric) {
+            # Both numeric: precision tolerance
+            value_diff_indices <- which(both_not_na & abs(new_column_data - old_column_data) > 1e-6)
+          } else if (!new_is_numeric && !old_is_numeric) {
+            # Both non-numeric: exact comparison
+            value_diff_indices <- which(both_not_na & new_column_data != old_column_data)
+          }
 
-      if (length(value_diff_indices) > 0) {
-        any_change_found <- TRUE
-        print_it(paste("CAUTION -", length(value_diff_indices), "values changed in", column_name), "br_violet")
+          if (length(value_diff_indices) > 0) {
+            any_change_found <- TRUE
+            print_it(paste("CAUTION -", length(value_diff_indices), "values changed in", column_name), "br_violet")
 
-        # Show unique cases and their counts
-        old_values <- old_column_data[value_diff_indices]
-        new_values <- new_column_data[value_diff_indices]
-        unique_changes <- unique(paste(old_values, "->", new_values))
-        for (change in unique_changes[1:min(5, length(unique_changes))]) {
-          change_count <- sum(paste(old_values, "->", new_values) == change)
-          print_it(paste(change, paste0("(", change_count), "cases)"), indent = 2)
+            # Show unique cases and their counts
+            old_values <- old_column_data[value_diff_indices]
+            new_values <- new_column_data[value_diff_indices]
+            unique_changes <- unique(paste(old_values, "->", new_values))
+            for (change in unique_changes[1:min(5, length(unique_changes))]) {
+              change_count <- sum(paste(old_values, "->", new_values) == change)
+              print_it(paste(change, paste0("(", change_count), "cases)"), indent = 2)
+            }
+          }
         }
       }
-    }
-  }
 
   return(any_change_found)
 }

--- a/R/check_data_changes.R
+++ b/R/check_data_changes.R
@@ -107,13 +107,16 @@ compare_dataframes <- function(new_data, old_data) {
     print_it("Finding columns for matching...", "yellow")
 
     available_columns <- common_columns[common_columns %in% numeric_var_list & common_columns != "id"]
-    print_it(paste("Numeric columns available:", length(available_columns)), "yellow")
+    print_it(paste("Numeric columns available:", paste(available_columns, collapse = ", ")), "yellow")
 
     columns_for_matching <- c()
     done <- FALSE
+    step <- 4
 
-    for (column in available_columns) {
-      columns_for_matching <- c(columns_for_matching, column)
+    for (i in seq(1, length(available_columns), by = step)) {
+      batch <- available_columns[i:min(i + step - 1, length(available_columns))]
+      columns_for_matching <- c(columns_for_matching, batch)
+      print_it(paste("Adding:", paste(batch, collapse = ", ")), "yellow")
       current_subset <- old_data[, columns_for_matching, drop = FALSE]
 
       if (anyDuplicated(current_subset) == 0) {

--- a/R/check_extraction.R
+++ b/R/check_extraction.R
@@ -371,6 +371,12 @@ check_extraction <- function(dataset, new_extraction = TRUE,
   }
 
   if (is.null(study_dir)) study_dir <- paste0(getwd(), "/")
-  check_data_changes(dataset, filename, study_dir, extracted_data_dir)
+  # suppress warnings related to differences in encoding
+  withCallingHandlers(
+    check_data_changes(dataset, filename, study_dir, extracted_data_dir),
+    warning = function(w) {
+      if (grepl("UTF-8", conditionMessage(w))) invokeRestart("muffleWarning")
+    }
+  )
 
 }

--- a/R/check_extraction.R
+++ b/R/check_extraction.R
@@ -371,12 +371,6 @@ check_extraction <- function(dataset, new_extraction = TRUE,
   }
 
   if (is.null(study_dir)) study_dir <- paste0(getwd(), "/")
-  # suppress warnings related to differences in encoding
-  withCallingHandlers(
-    check_data_changes(dataset, filename, study_dir, extracted_data_dir),
-    warning = function(w) {
-      if (grepl("UTF-8", conditionMessage(w))) invokeRestart("muffleWarning")
-    }
-  )
+  check_data_changes(dataset, filename, study_dir, extracted_data_dir)
 
 }

--- a/R/check_extraction.R
+++ b/R/check_extraction.R
@@ -30,15 +30,15 @@ check_extraction <- function(dataset, new_extraction = TRUE,
   ## Read data
   # standard country names
   # countrylist <- read.csv("S:/Projects/HeightProject/Original dataset/Covariates/country-list-2023-new.csv")
-  countrylist <- ncdrisc::countrylist
+  countrylist <- suppressWarnings(ncdrisc::countrylist)
 
   # standard variable name list - the list should be updated separately
   # std_names_list <- read.csv("S:/Projects/HeightProject/Original dataset/Data/Surveys/__Extraction Template/standard_variable_names.csv")
-  std_names_list <- ncdrisc::std_names_list
+  std_names_list <- suppressWarnings(ncdrisc::std_names_list)
 
   # List of high-altitutde countries that Hb needs adjusting
   # high_altitude_countries <- read.csv("S:/Projects/HeightProject/Original dataset/Anaemia/altitude info/high_altitude_countries.csv")
-  high_altitude_countries <- ncdrisc::high_altitude_countries
+  high_altitude_countries <- suppressWarnings(ncdrisc::high_altitude_countries)
 
   # Legacy naming issue
   # we use ha1c in extraction but hba1c downstream - rename hba1c variables to ha1c for these checks


### PR DESCRIPTION
Fixes a bug that caused data loss when reading old files in Extracted survey, which were written using UTF-8. The data loss made it impossible to compare new extractions with these files to ensure there are no unintended data changes. Now, the previously extracted data file that the new extraction is compared against is read using either latin1 or UTF-8, whichever results in the largest number of rows being read

Updates the logic for matching rows between the new extraction and the comparison file. Now, it will prompt the user to specify whether to match on the id column or automatically on other columns. In the latter case, it warns the user that the process could be slow for large datasets, and it could not even be successful (if there are duplicate rows).

Makes the matching process faster, even for large datasets, by using an index instead of a loop.